### PR TITLE
Fix/sceneglobalcontainer upm bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,20 +3,24 @@
 ## Version 0.8.2
 
 ### Packaging
+
 - Added Unity Package Manager (UPM) support.
 - Package can now be installed directly via Git URL:  
   `https://github.com/alexanderlarsen/Saneject.git?path=UnityProject/Saneject/Assets/Plugins/Saneject`
 - No changes to runtime or editor functionality.
+- Fixed a bug in `SceneGlobalContainer` that made it break in sample imported via UPM.
 
 ## Version 0.8.1
 
 ### CI/Testing
+
 - Added assembly definition files for runtime and test code to ensure CI discovers and runs tests consistently across Unity versions.
 - Moved test `Resources` folder into a folder covered by an assembly definition so `Resources.Load` works in CI.
 - Updated test setup to automatically bypass injection confirmation prompts when running in batch mode, fixing mass test failures in CI.
 - Confirmed automated tests now pass for all supported Unity versions.
 
 ### Editor
+
 - No functional changes to runtime/editor features, only improvements to test reliability and CI integration.
 
 ## Version 0.8.0

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Global/GlobalBinding.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Global/GlobalBinding.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Plugins.Saneject.Runtime.Global
+{
+    /// <summary>
+    /// Serializable data for one global binding: stores the type and the <see cref="object" /> instance.
+    /// </summary>
+    [Serializable]
+    public class GlobalBinding
+    {
+        [SerializeField]
+        private Object instance;
+
+        public GlobalBinding(Object obj)
+        {
+            instance = obj;
+        }
+
+        public Type Type => instance != null ? instance.GetType() : null;
+        public Object Instance => instance;
+    }
+}

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Global/GlobalBinding.cs.meta
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Global/GlobalBinding.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: dee2b6c937f64bf0a2ee9e76c76ae1b6
+timeCreated: 1755254951

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Global/SceneGlobalContainer.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Global/SceneGlobalContainer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using Plugins.Saneject.Runtime.Attributes;
 using Plugins.Saneject.Runtime.Extensions;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -20,7 +21,7 @@ namespace Plugins.Saneject.Runtime.Global
     [DefaultExecutionOrder(-10000)]
     public class SceneGlobalContainer : MonoBehaviour
     {
-        [SerializeField]
+        [SerializeField, Attributes.ReadOnly]
         private List<GlobalBinding> globalBindings = new();
 
         /// <summary>
@@ -39,28 +40,6 @@ namespace Plugins.Saneject.Runtime.Global
         {
             foreach (GlobalBinding binding in globalBindings)
                 GlobalScope.Unregister(binding.Type);
-        }
-
-        /// <summary>
-        /// Serializable data for one global binding: stores the type and the <see cref="Object" /> instance.
-        /// </summary>
-        [Serializable]
-        private class GlobalBinding
-        {
-            [SerializeField]
-            private string typeName;
-
-            [SerializeField]
-            private Object instance;
-
-            public GlobalBinding(Object obj)
-            {
-                instance = obj;
-                typeName = obj.GetType().AssemblyQualifiedName;
-            }
-
-            public Type Type => Type.GetType(typeName);
-            public Object Instance => instance;
         }
 
 #if UNITY_EDITOR

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/Scenes/GameScene.unity
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/Scenes/GameScene.unity
@@ -119,67 +119,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &278480782
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 278480784}
-  - component: {fileID: 278480783}
-  m_Layer: 0
-  m_Name: SceneGlobalContainer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &278480783
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 278480782}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4fc23f65d0d943be83178defc43e5484, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  globalBindings:
-  - typeName: Plugins.Saneject.Samples.DemoGame.Scripts.PlayerSystems.Player, Assembly-CSharp-firstpass,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    instance: {fileID: 142810265356923021}
-  - typeName: Plugins.Saneject.Samples.DemoGame.Scripts.Enemies.EnemyManager, Assembly-CSharp-firstpass,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    instance: {fileID: 2874387223255488611}
-  - typeName: Plugins.Saneject.Samples.DemoGame.Scripts.Highscore.ScoreManager, Assembly-CSharp-firstpass,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    instance: {fileID: 15540888646719327}
-  - typeName: Plugins.Saneject.Samples.DemoGame.Scripts.Camera.CameraController,
-      Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    instance: {fileID: 274076467875348428}
-  - typeName: Plugins.Saneject.Samples.DemoGame.Scripts.GameState.GameStateManager,
-      Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    instance: {fileID: 559519672}
-  createdByDependencyInjector: 1
---- !u!4 &278480784
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 278480782}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &345728943
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -663,6 +602,57 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 807967c59f124e67b11a0a22e885cbbe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1737687864
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1737687866}
+  - component: {fileID: 1737687865}
+  m_Layer: 0
+  m_Name: SceneGlobalContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1737687865
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1737687864}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4fc23f65d0d943be83178defc43e5484, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  globalBindings:
+  - instance: {fileID: 142810265356923021}
+  - instance: {fileID: 2874387223255488611}
+  - instance: {fileID: 15540888646719327}
+  - instance: {fileID: 274076467875348428}
+  - instance: {fileID: 559519672}
+  createdByDependencyInjector: 1
+--- !u!4 &1737687866
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1737687864}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &15540888646719327
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1301,4 +1291,4 @@ SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 7250975890217056284}
-  - {fileID: 278480784}
+  - {fileID: 1737687866}

--- a/UnityProject/Saneject/ProjectSettings/EditorBuildSettings.asset
+++ b/UnityProject/Saneject/ProjectSettings/EditorBuildSettings.asset
@@ -5,15 +5,15 @@ EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Scenes:
-  - enabled: 1
+  - enabled: 0
     path: Assets/Plugins/Saneject/Samples/DemoGame/StartScene.unity
     guid: 15d7f5558018bbb42a18f6ec8141f383
-  - enabled: 1
-    path: Assets/Plugins/Saneject/Samples/DemoGame/Scenes/GameScene.unity
-    guid: aa011174a9d382c4aa562d4014794a47
-  - enabled: 1
+  - enabled: 0
     path: Assets/Plugins/Saneject/Samples/DemoGame/Scenes/UIScene.unity
     guid: 51d3d79ee5eba1341a73cecefb1ef13b
+  - enabled: 0
+    path: Assets/Plugins/Saneject/Samples/DemoGame/Scenes/GameScene.unity
+    guid: aa011174a9d382c4aa562d4014794a47
   m_configObjects:
     com.unity.input.settings.actions: {fileID: -944628639613478452, guid: 052faaac586de48259a63d0c4782560b, type: 3}
   m_UseUCBPForAssetBundles: 0


### PR DESCRIPTION
- Removed `typeName` string from `GlobalBinding` and stopped relying on `SerializedProperty` to display type.
- Updated `SceneGlobalContainerEditor` to use reflection to directly access `GlobalBinding.Type` and `GlobalBinding.Instance` at runtime.
- Marked `globalBindings` read-only in the inspector.