### PR TITLE
Add prefab-to-prefab isolation and extend context filtering tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 ﻿# Saneject Changelog
 
+## Version 0.10.1
+
+### Changes
+
+- Added **prefab-to-prefab isolation** to context filtering.
+    - Prefab instances can no longer resolve components from other prefab instances.
+    - Prefab assets can no longer resolve components from other prefab assets.
+    - This ensures prefab-scoped dependencies remain stable and do not leak across unrelated prefabs.
+
+### Tests
+
+- Extended **ContextFilteringTests** to cover:
+    - Rejection of cross-prefab references when filtering is enabled.
+    - Rejection of prefab asset references when filtering is enabled.
+    - Confirmation that cross-context links are allowed when filtering is disabled.
+- Verified prefab isolation does not interfere with scene or proxy workflows.
+
 ## Version 0.10.0
 
 ### Features

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
@@ -2,7 +2,7 @@
   "name": "com.alexanderlarsen.saneject",
   "author": "Alexander Larsen",
   "displayName": "Saneject",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Unity Editor dependency injection framework for scenes and prefabs. Bind and resolve your dependencies entirely in the Editor with an inspector-first workflow, including full support for serialized interfaces. No runtime container, no extra lifecycles. Just fast, deterministic DI that feels native to Unity.",
   "documentationUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/README.md",
   "changelogUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/CHANGELOG.md",


### PR DESCRIPTION
- Extended context isolation to block prefab-to-prefab references in addition to scene ↔ prefab links.
- Implemented per-target and per-dependency context key checks to ensure dependencies only resolve within the same scene, prefab instance, or prefab asset root.
- Updated filtering logic to distinguish between scene objects, prefab instances, and prefab assets.
- Added new tests to verify that cross-prefab references are rejected and isolation rules are enforced consistently.