### PR TITLE
Version 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ﻿# Saneject Changelog
 
+## Version 0.14.0
+
+### Features
+
+- Added contextual right-click menu item in the Inspector: **Filter Logs By This Component**.  
+  Copies the component’s full transform path into the Console search bar.
+    - For regular components, filters logs by their hierarchy path.
+    - For `Scope` components, automatically filters by the scope’s type name.  
+      This makes it easy to isolate errors and warnings for a single component or scope in large projects.
+
 ## Version 0.13.1
 
 ### Fixes

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Inspectors/MonoBehaviourFallbackInspector.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Inspectors/MonoBehaviourFallbackInspector.cs
@@ -1,4 +1,6 @@
 ﻿using Plugins.Saneject.Editor.Utility;
+using Plugins.Saneject.Runtime.Scopes;
+using Saneject.Plugins.Saneject.Editor.Utility;
 using UnityEditor;
 using UnityEngine;
 
@@ -17,6 +19,20 @@ namespace Plugins.Saneject.Editor.Inspectors
         public override void OnInspectorGUI()
         {
             SanejectInspector.DrawDefault(serializedObject, targets, target);
+        }
+
+        [MenuItem("CONTEXT/Component/Filter Logs By This Component")]
+        private static void FilterBindingLogsForComponent(MenuCommand command)
+        {
+            Component comp = (Component)command.context;
+
+            if (comp is Scope scope)
+            {
+                ConsoleUtils.SetSearch($"{scope.GetType().Name}");
+                return;
+            }
+
+            ConsoleUtils.SetSearch($"{comp.GetComponentPath()}");
         }
     }
 }

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Utility/ConsoleUtils.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Utility/ConsoleUtils.cs
@@ -11,5 +11,27 @@ namespace Saneject.Plugins.Saneject.Editor.Utility
             MethodInfo clearMethod = logEntries?.GetMethod("Clear", BindingFlags.Static | BindingFlags.Public);
             clearMethod?.Invoke(null, null);
         }
+
+        public static void SetSearch(string query)
+        {
+            // Update backend filter
+            Type logEntriesType = typeof(UnityEditor.Editor).Assembly.GetType("UnityEditor.LogEntries");
+            MethodInfo setFilteringText = logEntriesType.GetMethod("SetFilteringText", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            setFilteringText?.Invoke(null, new object[] { query });
+
+            // Update visible search box text
+            Type consoleWindowType = typeof(UnityEditor.Editor).Assembly.GetType("UnityEditor.ConsoleWindow");
+            FieldInfo field = consoleWindowType.GetField("ms_ConsoleWindow", BindingFlags.Static | BindingFlags.NonPublic);
+            object consoleInstance = field?.GetValue(null);
+
+            if (consoleInstance != null)
+            {
+                FieldInfo searchField = consoleWindowType.GetField("m_SearchText", BindingFlags.Instance | BindingFlags.NonPublic);
+                searchField?.SetValue(consoleInstance, query);
+
+                MethodInfo repaint = consoleWindowType.GetMethod("Repaint", BindingFlags.Instance | BindingFlags.Public);
+                repaint?.Invoke(consoleInstance, null);
+            }
+        }
     }
 }

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Utility/NamePathUtils.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Utility/NamePathUtils.cs
@@ -67,6 +67,30 @@ namespace Plugins.Saneject.Editor.Utility
         }
 
         /// <summary>
+        /// Returns the logical name of a field, stripping compiler auto-property
+        /// backing syntax (&lt;Name&gt;k__BackingField) when present.
+        /// </summary>
+        public static string GetLogicalName(FieldInfo field)
+        {
+            string n = field.Name;
+
+            // Handle auto-property backing fields: <Name>k__BackingField
+            if (n.Length > 0 && n[0] == '<')
+            {
+                int end = n.IndexOf(">k__BackingField", StringComparison.Ordinal);
+                if (end > 1) return n.Substring(1, end - 1); // "InterfaceB1"
+            }
+
+            return n;
+        }
+
+        public static string GetComponentPath(this Component component)
+        {
+            string goPath = component.transform.GetHierarchyPath();
+            return $"{goPath}/{component.GetType().Name}";
+        }
+
+        /// <summary>
         /// Returns the logical segment name: if the segment is a C# compiler
         /// auto-property backing field (&lt;Name&gt;k__BackingField) return "Name";
         /// otherwise return the segment unchanged. Safe for non-backing segments
@@ -92,24 +116,6 @@ namespace Plugins.Saneject.Editor.Utility
         private static string GetHierarchyPath(this Transform transform)
         {
             return !transform.parent ? transform.name : $"{transform.parent.GetHierarchyPath()}/{transform.name}";
-        }
-        
-        /// <summary>
-        /// Returns the logical name of a field, stripping compiler auto-property
-        /// backing syntax (&lt;Name&gt;k__BackingField) when present.
-        /// </summary>
-        public static string GetLogicalName(FieldInfo field)
-        {
-            string n = field.Name;
-
-            // Handle auto-property backing fields: <Name>k__BackingField
-            if (n.Length > 0 && n[0] == '<')
-            {
-                int end = n.IndexOf(">k__BackingField", StringComparison.Ordinal);
-                if (end > 1) return n.Substring(1, end - 1); // "InterfaceB1"
-            }
-
-            return n;
         }
     }
 }

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
@@ -2,7 +2,7 @@
   "name": "com.alexanderlarsen.saneject",
   "author": "Alexander Larsen",
   "displayName": "Saneject",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Unity Editor dependency injection framework for scenes and prefabs. Bind and resolve your dependencies entirely in the Editor with an inspector-first workflow, including full support for serialized interfaces. No runtime container, no extra lifecycles. Just fast, deterministic DI that feels native to Unity.",
   "documentationUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/README.md",
   "changelogUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/CHANGELOG.md",


### PR DESCRIPTION
## Features

- Added contextual right-click menu item in the Inspector: **Filter Logs By This Component**.  
  Copies the component’s full transform path into the Console search bar.
    - For regular components, filters logs by their hierarchy path.
    - For `Scope` components, automatically filters by the scope’s type name.  
      This makes it easy to isolate errors and warnings for a single component or scope in large projects.