### PR TITLE
Version 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## Version 0.16.0
 
-### Changes
+### Features
 
-- Added inspector support to reflect `[Tooltip]` from the original `[SerializeInterface]` field onto its generated backing field, for both single references and collections.
+- Display scope path in `Scope` Inspector
+    - Implemented scope path visualization in `ScopeEditor` Inspector, showing the path from the topmost scope to the current one.
+    - Added `Show Scope Path` option to `UserSettings` to toggle parent scope path visibility.
+    - Jump-to-scope buttons per path item for easier navigation in the hierarchy.
+- Inspector support to reflect `[Tooltip]` from the original `[SerializeInterface]` field onto its generated backing field, for both single references and collections.
+
+## Fixes
+
+- Display friendly type names in `SceneGlobalContainerEditor` inspector, raw type names are now shown with user-friendly formatting and spaces, matching the default Unity inspector.
 
 ## Version 0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ﻿# Saneject Changelog
 
+## Version 0.16.0
+
+### Changes
+
+- Added inspector support to reflect `[Tooltip]` from the original `[SerializeInterface]` field onto its generated backing field, for both single references and collections.
+
 ## Version 0.15.0
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,28 @@
 
 ### Features
 
-- Display scope path in `Scope` Inspector
-    - Implemented scope path visualization in `ScopeEditor` Inspector, showing the path from the topmost scope to the current one.
-    - Added `Show Scope Path` option to `UserSettings` to toggle parent scope path visibility.
-    - Jump-to-scope buttons per path item for easier navigation in the hierarchy.
-- Inspector support to reflect `[Tooltip]` from the original `[SerializeInterface]` field onto its generated backing field, for both single references and collections.
+- Display scope path in Inspector
+    - Shows the chain of parent scopes from the topmost scope down to the current one.
+    - Added a **Show Scope Path** toggle in User Settings.
+    - Includes jump-to-scope buttons for quick navigation.
+- Inspector tooltip support for `[SerializeInterface]`
+    - `[Tooltip]` text on a `[SerializeInterface]` field is now reflected on its generated backing field.
 - Binding identity strings now list the names of their targets and members, making log messages clearer and helping distinguish bindings whose uniqueness comes from those specific targets or members.
+- Added global binding context filtering
+    - Skip prefab components by default when registering in SceneGlobalContainer (can be turned off in user settings - but not recommended).
+    - Injection logic now tracks invalid bindings for clearer debugging.
+- Added MonoBehaviour script field to inspectors
+    - Both `ScopeEditor` and `SceneGlobalContainerEditor` now show the standard “Script” field with improved spacing and headers.
 
-## Fixes
+### Fixes
 
-- Display friendly type names in `SceneGlobalContainerEditor` inspector, raw type names are now shown with user-friendly formatting and spaces, matching the default Unity inspector.
+- Nicified type names in `SceneGlobalContainerEditor` inspector – raw type names are now shown with user-friendly formatting and spaces, matching the default Unity inspector.
+
+### Improvements
+
+- Enhanced error handling and logging for global dependency resolution
+    - Error messages include the global binding identity for better debugging clarity.
+    - Duplicate bindings and resolution failures now provide more detailed context.
 
 ## Version 0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     - Added `Show Scope Path` option to `UserSettings` to toggle parent scope path visibility.
     - Jump-to-scope buttons per path item for easier navigation in the hierarchy.
 - Inspector support to reflect `[Tooltip]` from the original `[SerializeInterface]` field onto its generated backing field, for both single references and collections.
+- Binding identity strings now list the names of their targets and members, making log messages clearer and helping distinguish bindings whose uniqueness comes from those specific targets or members.
 
 ## Fixes
 

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Core/DependencyInjector.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Core/DependencyInjector.cs
@@ -350,7 +350,7 @@ namespace Plugins.Saneject.Editor.Core
 
                     if (!resolved)
                     {
-                        Debug.LogError($"Saneject: Could not resolve global dependency in scope '{scope.gameObject.name}'", scope);
+                        Debug.LogError($"Saneject: Global binding failed to locate a dependency {globalBinding.GetBindingSignature()}.", scope);
                         continue;
                     }
 

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Inspectors/SceneGlobalContainerEditor.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Inspectors/SceneGlobalContainerEditor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Reflection;
+using Plugins.Saneject.Editor.Utility;
 using Plugins.Saneject.Runtime.Global;
 using Plugins.Saneject.Runtime.Scopes;
 using Plugins.Saneject.Runtime.Settings;
@@ -19,6 +20,8 @@ namespace Plugins.Saneject.Editor.Inspectors
     {
         public override void OnInspectorGUI()
         {
+            SanejectInspector.DrawMonoBehaviourScriptField(targets, target);
+
             if (UserSettings.ShowHelpBoxes)
                 EditorGUILayout.HelpBox(
                     $"• {nameof(SceneGlobalContainer)} is managed automatically by Saneject.\n" +
@@ -33,6 +36,10 @@ namespace Plugins.Saneject.Editor.Inspectors
 
             if (bindingsProp.arraySize == 0)
                 EditorGUILayout.LabelField("[No global objects currently registered in this scene]", EditorStyles.wordWrappedLabel);
+
+            EditorGUILayout.Space(8);
+
+            EditorGUILayout.LabelField("Global Scene Objects", EditorStyles.boldLabel);
 
             using (new EditorGUI.DisabledScope(true))
             {

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Inspectors/SceneGlobalContainerEditor.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Inspectors/SceneGlobalContainerEditor.cs
@@ -55,8 +55,8 @@ namespace Plugins.Saneject.Editor.Inspectors
                         Type type = (Type)typeProp.GetValue(binding);
                         Object instance = (Object)instanceProp.GetValue(binding);
 
-                        // Draw however you want
-                        EditorGUILayout.ObjectField(type?.Name ?? "(Invalid Type)", instance, typeof(Object), true);
+                        string displayName = type != null ? ObjectNames.NicifyVariableName(type.Name) : "(Invalid Type)";
+                        EditorGUILayout.ObjectField(displayName, instance, typeof(Object), true);
                     }
             }
 

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Inspectors/ScopeEditor.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Inspectors/ScopeEditor.cs
@@ -34,6 +34,8 @@ namespace Plugins.Saneject.Editor.Inspectors
 
         public override void OnInspectorGUI()
         {
+            SanejectInspector.DrawMonoBehaviourScriptField(targets, target);
+            
             if (UserSettings.ShowHelpBoxes)
                 EditorGUILayout.HelpBox(
                     "• Two scope types: Prefab and Scene (both managed by this Scope component).\n" +

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Inspectors/ScopeEditor.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Inspectors/ScopeEditor.cs
@@ -23,13 +23,11 @@ namespace Plugins.Saneject.Editor.Inspectors
         {
             BuildScopeHierarchy();
             EditorApplication.hierarchyChanged += BuildScopeHierarchy;
-            Debug.Log("OnEnable");
         }
 
         private void OnDisable()
         {
             EditorApplication.hierarchyChanged -= BuildScopeHierarchy;
-            Debug.Log("OnDisable");
         }
 
         public override void OnInspectorGUI()

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Settings/UserSettingsEditorWindow.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Settings/UserSettingsEditorWindow.cs
@@ -145,6 +145,14 @@ namespace Plugins.Saneject.Editor.Settings
                 onChanged: newValue => UserSettings.ShowHelpBoxes = newValue,
                 repaintInspectors: true
             );
+            
+            DrawToggle(
+                label: "Show Scope Path",
+                tooltip: "Display the path of parent scopes from the topmost scope down to this one in the Inspector.",
+                currentValue: UserSettings.ShowScopePath,
+                onChanged: newValue => UserSettings.ShowScopePath = newValue,
+                repaintInspectors: true
+            );
 
             EditorGUILayout.Space(10);
             EditorGUILayout.LabelField("Play Mode Logging (Editor Only)", EditorStyles.boldLabel);

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Bindings/Binding.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Bindings/Binding.cs
@@ -48,6 +48,16 @@ namespace Plugins.Saneject.Runtime.Bindings
         public bool IsAssetBinding { get; private set; }
         public bool IsProxyBinding { get; private set; }
 
+        public string[] GetTargetNames()
+        {
+            return injectionTargetQualifiers.Select(f => f.targetType.Name).ToArray();
+        }
+        
+        public string[] GetMemberNames()
+        {
+            return injectionTargetMemberQualifiers.Select(f => f.memberName).ToArray();
+        }
+        
         /// <summary>
         /// Constructs a readable binding name used by the <c>DependencyInjector</c> for logging purposes,
         /// including interface and concrete type names and an optional ID.

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Bindings/BindingSignatureHelper.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Bindings/BindingSignatureHelper.cs
@@ -21,7 +21,9 @@ namespace Plugins.Saneject.Runtime.Bindings
                 binding.InterfaceType,
                 binding.ConcreteType,
                 binding.Ids,
-                binding.Scope
+                binding.Scope,
+                binding.GetTargetNames(),
+                binding.GetMemberNames()
             );
         }
 
@@ -64,7 +66,9 @@ namespace Plugins.Saneject.Runtime.Bindings
             Type interfaceType,
             Type concreteType,
             string[] ids,
-            Scope scope)
+            Scope scope,
+            string[] targetNames,
+            string[] memberNames)
         {
             StringBuilder sb = new();
             sb.Append("[Binding: ");
@@ -96,6 +100,20 @@ namespace Plugins.Saneject.Runtime.Bindings
                 sb.Append(" | ");
                 sb.Append(ids.Length == 1 ? "ID: " : "IDs: ");
                 sb.Append(string.Join(", ", ids));
+            }
+
+            if (targetNames is { Length: > 0 })
+            {
+                sb.Append(" | ");
+                sb.Append(targetNames.Length == 1 ? "To target: " : "To targets: ");
+                sb.Append(string.Join(", ", targetNames));
+            }
+
+            if (memberNames is { Length: > 0 })
+            {
+                sb.Append(" | ");
+                sb.Append(memberNames.Length == 1 ? "To member: " : "To members: ");
+                sb.Append(string.Join(", ", memberNames));
             }
 
             sb.Append($" | {(scope.gameObject.IsPrefab() ? "Prefab" : "Scene")} scope: {scope.GetType().Name}");

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Global/SceneGlobalContainer.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Global/SceneGlobalContainer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using Plugins.Saneject.Runtime.Attributes;
 using Plugins.Saneject.Runtime.Extensions;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -51,18 +50,16 @@ namespace Plugins.Saneject.Runtime.Global
         /// Editor-only; not used at runtime.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Add(Object obj)
+        public bool Add(Object obj)
         {
             Type objType = obj.GetType();
 
             if (globalBindings.Exists(binding => binding.Type == objType))
-            {
-                Debug.LogError($"Saneject: GlobalSceneRegistry can only contain one binding for type '{objType}'");
-                return;
-            }
+                return false;
 
             GlobalBinding binding = new(obj);
             globalBindings.Add(binding);
+            return true;
         }
 
         private void OnValidate()

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Settings/UserSettings.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Settings/UserSettings.cs
@@ -48,6 +48,12 @@ namespace Plugins.Saneject.Runtime.Settings
             set => SetBool(value);
         }
 
+        public static bool ShowScopePath
+        {
+            get => GetBool(defaultValue: true);
+            set => SetBool(value);
+        }
+
         // Play Mode Logging
         public static bool LogProxyResolve
         {

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
@@ -2,7 +2,7 @@
   "name": "com.alexanderlarsen.saneject",
   "author": "Alexander Larsen",
   "displayName": "Saneject",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Unity Editor dependency injection framework for scenes and prefabs. Bind and resolve your dependencies entirely in the Editor with an inspector-first workflow, including full support for serialized interfaces. No runtime container, no extra lifecycles. Just fast, deterministic DI that feels native to Unity.",
   "documentationUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/README.md",
   "changelogUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/CHANGELOG.md",

--- a/UnityProject/Saneject/Assets/Tests/Editor/Global/PrefabGlobalFilteringTest.cs
+++ b/UnityProject/Saneject/Assets/Tests/Editor/Global/PrefabGlobalFilteringTest.cs
@@ -1,0 +1,139 @@
+﻿using System.Collections;
+using System.Reflection;
+using NUnit.Framework;
+using Plugins.Saneject.Editor.Core;
+using Plugins.Saneject.Runtime.Global;
+using Plugins.Saneject.Runtime.Settings;
+using Tests.Runtime;
+using Tests.Runtime.Component;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Tests.Editor.Global
+{
+    public class PrefabGlobalFilteringTest : BaseBindingTest
+    {
+        private GameObject root;
+        private bool prevFilterBySameContext;
+
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+            prevFilterBySameContext = UserSettings.FilterBySameContext;
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            base.TearDown();
+            UserSettings.FilterBySameContext = prevFilterBySameContext;
+        }
+
+        [Test]
+        public void PrefabComponent_NotRegisteredAsGlobal_WhenFilteringEnabled()
+        {
+            IgnoreErrorMessages();
+            UserSettings.FilterBySameContext = true;
+
+            // Add components
+            TestScope scope = root.AddComponent<TestScope>();
+            ComponentRequester requester = root.AddComponent<ComponentRequester>();
+
+            GameObject prefabAsset = AssetDatabase.LoadAssetAtPath<GameObject>(
+                "Assets/Tests/Runtime/Resources/Test/Prefab 1.prefab");
+
+            GameObject prefabInstance = PrefabUtility.InstantiatePrefab(prefabAsset) as GameObject;
+            InjectableComponent injectable = prefabInstance.AddComponent<InjectableComponent>();
+
+            // Set up bindings
+            BindGlobal<InjectableComponent>(scope).FromInstance(injectable);
+
+            // Inject
+            DependencyInjector.InjectSceneDependencies();
+
+            // Assert
+            SceneGlobalContainer container = Object.FindFirstObjectByType<SceneGlobalContainer>();
+
+            if (container != null)
+            {
+                FieldInfo field = typeof(SceneGlobalContainer)
+                    .GetField("globalBindings", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                IEnumerable list = field.GetValue(container) as IEnumerable;
+
+                bool found = false;
+
+                foreach (object item in list)
+                {
+                    PropertyInfo instanceProp = item.GetType().GetProperty("Instance", BindingFlags.Public | BindingFlags.Instance);
+                    Object instance = instanceProp?.GetValue(item) as Object;
+
+                    if (instance == injectable)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                Assert.IsFalse(found, "Prefab component should not be present in globalBindings when filtering is enabled.");
+            }
+
+            Assert.IsNull(requester.interfaceComponent,
+                "Requester should not resolve from prefab global binding when filtering is enabled.");
+        }
+
+        [Test]
+        public void PrefabComponent_RegisteredAsGlobal_WhenFilteringDisabled()
+        {
+            IgnoreErrorMessages();
+            UserSettings.FilterBySameContext = false;
+
+            // Add components
+            TestScope scope = root.AddComponent<TestScope>();
+
+            GameObject prefabAsset = AssetDatabase.LoadAssetAtPath<GameObject>(
+                "Assets/Tests/Runtime/Resources/Test/Prefab 1.prefab");
+
+            GameObject prefabInstance = PrefabUtility.InstantiatePrefab(prefabAsset) as GameObject;
+            InjectableComponent injectable = prefabInstance.AddComponent<InjectableComponent>();
+
+            // Set up bindings
+            BindGlobal<InjectableComponent>(scope).FromInstance(injectable);
+
+            // Inject
+            DependencyInjector.InjectSceneDependencies();
+
+            // Assert
+            SceneGlobalContainer container = Object.FindFirstObjectByType<SceneGlobalContainer>();
+            Assert.NotNull(container, "SceneGlobalContainer should exist when global binding is allowed.");
+
+            FieldInfo field = typeof(SceneGlobalContainer)
+                .GetField("globalBindings", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            IEnumerable list = field.GetValue(container) as IEnumerable;
+
+            bool found = false;
+
+            foreach (object item in list)
+            {
+                PropertyInfo instanceProp = item.GetType().GetProperty("Instance", BindingFlags.Public | BindingFlags.Instance);
+                Object instance = instanceProp?.GetValue(item) as Object;
+
+                if (instance == injectable)
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            Assert.IsTrue(found, "Prefab component should be present in globalBindings when filtering is disabled.");
+        }
+
+        protected override void CreateHierarchy()
+        {
+            root = new GameObject("Root");
+        }
+    }
+}

--- a/UnityProject/Saneject/Assets/Tests/Editor/Global/PrefabGlobalFilteringTest.cs.meta
+++ b/UnityProject/Saneject/Assets/Tests/Editor/Global/PrefabGlobalFilteringTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: dae708a5b3c3476f8249a74d07e7f6d5
+timeCreated: 1758195423


### PR DESCRIPTION
## Features

- Display scope path in Inspector
    - Shows the chain of parent scopes from the topmost scope down to the current one.
    - Added a **Show Scope Path** toggle in User Settings.
    - Includes jump-to-scope buttons for quick navigation.
- Inspector tooltip support for `[SerializeInterface]`
    - `[Tooltip]` text on a `[SerializeInterface]` field is now reflected on its generated backing field.
- Binding identity strings now list the names of their targets and members, making log messages clearer and helping distinguish bindings whose uniqueness comes from those specific targets or members.
- Added global binding context filtering
    - Skip prefab components by default when registering in SceneGlobalContainer (can be turned off in user settings - but not recommended).
    - Injection logic now tracks invalid bindings for clearer debugging.
- Added MonoBehaviour script field to inspectors
    - Both `ScopeEditor` and `SceneGlobalContainerEditor` now show the standard “Script” field with improved spacing and headers.

## Fixes

- Nicified type names in `SceneGlobalContainerEditor` inspector – raw type names are now shown with user-friendly formatting and spaces, matching the default Unity inspector.

## Improvements

- Enhanced error handling and logging for global dependency resolution
    - Error messages include the global binding identity for better debugging clarity.
    - Duplicate bindings and resolution failures now provide more detailed context.