### PR TITLE
Update sample game and bump version to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ﻿# Changelog
 
+## Version 1.0.2
+
+### Fixes
+
+- Updated sample game `GameSceneScope` to use a direct prefab reference instead of loading by asset path.
+- Fixed an issue where the Enemy prefab failed to load when importing the sample via UPM due to changed asset paths.
+
 ## Version 1.0.1
 
 ### Fixes

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/Prefabs/Enemy.prefab
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/Prefabs/Enemy.prefab
@@ -53,7 +53,7 @@ MonoBehaviour:
   markerTarget: {fileID: 9153909654693612790}
   markerImage: {fileID: 8796291780960885798}
   padding: 20
-  __mainCamera: {fileID: 11400000, guid: 7978de8b86aa00c45bfc0e66017c6669, type: 2}
+  __mainCamera: {fileID: 11400000, guid: 6bc598e349d387f49954cc9b133bd027, type: 2}
 --- !u!222 &8919195443713171182
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -163,7 +163,7 @@ MonoBehaviour:
   walkSpeed: 3
   runSpeed: 5
   evadeDistance: 3
-  __evadeTarget: {fileID: 11400000, guid: 11f2dbb6280a5c64fad4b2b2654f3645, type: 2}
+  __evadeTarget: {fileID: 11400000, guid: d5e5bdd8fbdcbd0449c516038844116b, type: 2}
 --- !u!33 &8924227375775184379
 MeshFilter:
   m_ObjectHideFlags: 0

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/CameraControllerProxyCFD6ED32 (FromGlobalScope).asset
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/CameraControllerProxyCFD6ED32 (FromGlobalScope).asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6a0055497d0b1084998ff4d4b286c43d, type: 3}
+  m_Script: {fileID: 11500000, guid: c693913ccbaad0742a66464b2ced63c9, type: 3}
   m_Name: CameraControllerProxyCFD6ED32 (FromGlobalScope)
   m_EditorClassIdentifier: 
   resolveMethod: 0

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/CameraControllerProxyCFD6ED32 (FromGlobalScope).asset.meta
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/CameraControllerProxyCFD6ED32 (FromGlobalScope).asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7978de8b86aa00c45bfc0e66017c6669
+guid: 6bc598e349d387f49954cc9b133bd027
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/CameraControllerProxyCFD6ED32.cs.meta
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/CameraControllerProxyCFD6ED32.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 6a0055497d0b1084998ff4d4b286c43d
+guid: c693913ccbaad0742a66464b2ced63c9

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/EnemyManagerProxyE81FC277 (FromGlobalScope).asset
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/EnemyManagerProxyE81FC277 (FromGlobalScope).asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0534a03fe1e8ee44cb0aa4a074fd6ad5, type: 3}
+  m_Script: {fileID: 11500000, guid: 1edbb9decdc50e64c9574aa20483974a, type: 3}
   m_Name: EnemyManagerProxyE81FC277 (FromGlobalScope)
   m_EditorClassIdentifier: 
   resolveMethod: 0

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/EnemyManagerProxyE81FC277 (FromGlobalScope).asset.meta
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/EnemyManagerProxyE81FC277 (FromGlobalScope).asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 32411652e43c2c14ab51ce82664e0a6e
+guid: 4ffca9d0d633fbb4c89125bc72529a35
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/EnemyManagerProxyE81FC277.cs.meta
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/EnemyManagerProxyE81FC277.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 0534a03fe1e8ee44cb0aa4a074fd6ad5
+guid: 1edbb9decdc50e64c9574aa20483974a

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/GameStateManagerProxy854760C8 (FromGlobalScope).asset
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/GameStateManagerProxy854760C8 (FromGlobalScope).asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 329aaa64cb625dc4d93e1874256e3fc1, type: 3}
+  m_Script: {fileID: 11500000, guid: b0afb70804cceb44d927fc0bfe9eb523, type: 3}
   m_Name: GameStateManagerProxy854760C8 (FromGlobalScope)
   m_EditorClassIdentifier: 
   resolveMethod: 0

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/GameStateManagerProxy854760C8 (FromGlobalScope).asset.meta
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/GameStateManagerProxy854760C8 (FromGlobalScope).asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: babb3733487338f488848f9052cdd531
+guid: 24172820d71051c42bae14406545d203
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/GameStateManagerProxy854760C8.cs.meta
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/GameStateManagerProxy854760C8.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 329aaa64cb625dc4d93e1874256e3fc1
+guid: b0afb70804cceb44d927fc0bfe9eb523

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/PlayerProxy8025BCC8 (FromGlobalScope).asset
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/PlayerProxy8025BCC8 (FromGlobalScope).asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cd68a219158d4644da9168421f5be1fc, type: 3}
+  m_Script: {fileID: 11500000, guid: 62e796f0a6098714c9d50284c63c6001, type: 3}
   m_Name: PlayerProxy8025BCC8 (FromGlobalScope)
   m_EditorClassIdentifier: 
   resolveMethod: 0

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/PlayerProxy8025BCC8 (FromGlobalScope).asset.meta
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/PlayerProxy8025BCC8 (FromGlobalScope).asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 11f2dbb6280a5c64fad4b2b2654f3645
+guid: d5e5bdd8fbdcbd0449c516038844116b
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/PlayerProxy8025BCC8.cs.meta
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/PlayerProxy8025BCC8.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: cd68a219158d4644da9168421f5be1fc
+guid: 62e796f0a6098714c9d50284c63c6001

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/SceneManagerProxy36FFF13A (FromGlobalScope).asset
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/SceneManagerProxy36FFF13A (FromGlobalScope).asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 163e07dc0dfa27642a8c9f90d8fae435, type: 3}
+  m_Script: {fileID: 11500000, guid: 1d14e89687e93a246ae37d08bfa4b121, type: 3}
   m_Name: SceneManagerProxy36FFF13A (FromGlobalScope)
   m_EditorClassIdentifier: 
   resolveMethod: 0

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/SceneManagerProxy36FFF13A (FromGlobalScope).asset.meta
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/SceneManagerProxy36FFF13A (FromGlobalScope).asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 150e36c50bb5ee54f98058aa14f8ed7d
+guid: 2d50bcddb05d6f942a0c7a1a6860e965
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/SceneManagerProxy36FFF13A (FromNewComponentOnNewGameObject, DDOL, Singleton).asset
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/SceneManagerProxy36FFF13A (FromNewComponentOnNewGameObject, DDOL, Singleton).asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 163e07dc0dfa27642a8c9f90d8fae435, type: 3}
+  m_Script: {fileID: 11500000, guid: 1d14e89687e93a246ae37d08bfa4b121, type: 3}
   m_Name: SceneManagerProxy36FFF13A (FromNewComponentOnNewGameObject, DDOL, Singleton)
   m_EditorClassIdentifier: 
   resolveMethod: 3

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/SceneManagerProxy36FFF13A (FromNewComponentOnNewGameObject, DDOL, Singleton).asset.meta
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/SceneManagerProxy36FFF13A (FromNewComponentOnNewGameObject, DDOL, Singleton).asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 740bd7dc3e02d43418989c5130f23049
+guid: ca4d538ccb97a2e4b84b07bc584a1dbd
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/SceneManagerProxy36FFF13A.cs.meta
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/SceneManagerProxy36FFF13A.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 163e07dc0dfa27642a8c9f90d8fae435
+guid: 1d14e89687e93a246ae37d08bfa4b121

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/ScoreManagerProxy766A5B5B (FromGlobalScope).asset
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/ScoreManagerProxy766A5B5B (FromGlobalScope).asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 18f7a00d44547834ea999923cfe4dfe0, type: 3}
+  m_Script: {fileID: 11500000, guid: 3dbec3c65d94ee14fbb460b77e903859, type: 3}
   m_Name: ScoreManagerProxy766A5B5B (FromGlobalScope)
   m_EditorClassIdentifier: 
   resolveMethod: 0

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/ScoreManagerProxy766A5B5B (FromGlobalScope).asset.meta
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/ScoreManagerProxy766A5B5B (FromGlobalScope).asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 70848ceab7bdcb540a198a71111bd04c
+guid: c2ed40acd14c09547af19b4b10870546
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/ScoreManagerProxy766A5B5B.cs.meta
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/RuntimeProxies/ScoreManagerProxy766A5B5B.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 18f7a00d44547834ea999923cfe4dfe0
+guid: 3dbec3c65d94ee14fbb460b77e903859

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/Scenes/GameScene.unity
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/Scenes/GameScene.unity
@@ -741,6 +741,7 @@ MonoBehaviour:
   - {fileID: 274076467875348428}
   - {fileID: 559519672}
   proxySwapTargets: []
+  enemyPrefab: {fileID: 4772603026273723368, guid: a2049a1cff4cb1244a304c467207ae48, type: 3}
 --- !u!4 &7619134572789606709
 Transform:
   m_ObjectHideFlags: 0

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/Scenes/UIScene.unity
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/Scenes/UIScene.unity
@@ -1391,10 +1391,10 @@ MonoBehaviour:
     enemiesLeftText: {fileID: 1886484449}
     scoreText: {fileID: 163977813}
     restartButton: {fileID: 1084788498}
-  __gameStateObservable: {fileID: 11400000, guid: babb3733487338f488848f9052cdd531, type: 2}
-  __scoreObservable: {fileID: 11400000, guid: 70848ceab7bdcb540a198a71111bd04c, type: 2}
-  __enemyObservable: {fileID: 11400000, guid: 32411652e43c2c14ab51ce82664e0a6e, type: 2}
-  __sceneManager: {fileID: 11400000, guid: 150e36c50bb5ee54f98058aa14f8ed7d, type: 2}
+  __gameStateObservable: {fileID: 11400000, guid: 24172820d71051c42bae14406545d203, type: 2}
+  __scoreObservable: {fileID: 11400000, guid: c2ed40acd14c09547af19b4b10870546, type: 2}
+  __enemyObservable: {fileID: 11400000, guid: 4ffca9d0d633fbb4c89125bc72529a35, type: 2}
+  __sceneManager: {fileID: 11400000, guid: 2d50bcddb05d6f942a0c7a1a6860e965, type: 2}
 --- !u!1 &2130916102
 GameObject:
   m_ObjectHideFlags: 0
@@ -1450,9 +1450,9 @@ MonoBehaviour:
     gameObject: {fileID: 2130916102}
     enemiesLeftText: {fileID: 1958942919}
     scoreText: {fileID: 1373578029}
-  __gameStateObservable: {fileID: 11400000, guid: babb3733487338f488848f9052cdd531, type: 2}
-  __scoreObservable: {fileID: 11400000, guid: 70848ceab7bdcb540a198a71111bd04c, type: 2}
-  __enemyObservable: {fileID: 11400000, guid: 32411652e43c2c14ab51ce82664e0a6e, type: 2}
+  __gameStateObservable: {fileID: 11400000, guid: 24172820d71051c42bae14406545d203, type: 2}
+  __scoreObservable: {fileID: 11400000, guid: c2ed40acd14c09547af19b4b10870546, type: 2}
+  __enemyObservable: {fileID: 11400000, guid: 4ffca9d0d633fbb4c89125bc72529a35, type: 2}
 --- !u!114 &2130916106
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/Scripts/Scopes/GameSceneScope.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/Scripts/Scopes/GameSceneScope.cs
@@ -14,6 +14,9 @@ namespace Plugins.Saneject.Samples.DemoGame.Scripts.Scopes
     /// </summary>
     public class GameSceneScope : Scope
     {
+        [SerializeField]
+        private GameObject enemyPrefab;
+        
         /// <summary>
         /// Declares the gameplay bindings and global registrations used throughout the sample.
         /// </summary>
@@ -49,7 +52,7 @@ namespace Plugins.Saneject.Samples.DemoGame.Scripts.Scopes
             BindAsset<GameObject>()
                 .ToTarget<EnemyManager>()
                 .ToMember("enemyPrefab")
-                .FromAssetLoad("Assets/Plugins/Saneject/Samples/DemoGame/Prefabs/Enemy.prefab");
+                .FromInstance(enemyPrefab);
         }
     }
 }

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/StartScene.unity
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/StartScene.unity
@@ -164,7 +164,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5594851247574d3e820358d611189efd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  __sceneManager: {fileID: 11400000, guid: 740bd7dc3e02d43418989c5130f23049, type: 2}
+  __sceneManager: {fileID: 11400000, guid: ca4d538ccb97a2e4b84b07bc584a1dbd, type: 2}
 --- !u!114 &275804401
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
@@ -2,7 +2,7 @@
   "name": "com.alexanderlarsen.saneject",
   "author": "Alexander Larsen",
   "displayName": "Saneject",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Inject dependencies in the Unity Editor, not Play Mode, by writing them directly into serialized fields at edit-time using familiar DI APIs, so everything stays visible in the Inspector, including interfaces.\n\nNo runtime container. No startup cost. No hidden wiring. No weird lifecycles. Just simple, deterministic edit-time DI that works with Unity, not around it.",
   "documentationUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/README.md",
   "changelogUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/CHANGELOG.md",


### PR DESCRIPTION
- Updated sample game `GameSceneScope` to use a direct prefab reference instead of loading by asset path.
- Fixed an issue where the Enemy prefab failed to load when importing the sample via UPM due to changed asset paths.
- Rebuilt sample game runtime proxies because some of them were unused.