### PR TITLE
Version 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ﻿# Changelog
 
+## Version 1.0.3
+
+### Fixes
+
+- Fixed `GlobalScope` persistence across Play Mode sessions when Unity domain reload is disabled.
+- Added an editor Play Mode lifecycle reset that clears `GlobalScope` on Enter Edit Mode (after Play Mode exit), ensuring stale global registrations do not leak into the next run.
+- This makes `BindGlobal<T>()` and runtime proxy singleton registrations behave correctly regardless of whether domain reload is enabled.
+
 ## Version 1.0.2
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### Fixes
 
-- Fixed `GlobalScope` persistence across Play Mode sessions when Unity domain reload is disabled.
-- Added an editor Play Mode lifecycle reset that clears `GlobalScope` on Enter Edit Mode (after Play Mode exit), ensuring stale global registrations do not leak into the next run.
-- This makes `BindGlobal<T>()` and runtime proxy singleton registrations behave correctly regardless of whether domain reload is enabled.
+- Fixed `GlobalScope` persistence when domain reload is disabled.
+  - Added an editor Play Mode lifecycle reset that clears `GlobalScope` on Enter Edit Mode after Play Mode exit.
+  - Prevents stale global registrations from leaking into the next run.
+  - Ensures `BindGlobal<T>()` and runtime proxy singleton registrations behave correctly regardless of domain reload settings.
+- Fixed sample game player-build failures caused by legacy hide flags on shipped scopes.
+  - Removed serialized `DontSaveInBuild` flags that remained on `PlayerScope`, `GameSceneScope`, and `UISceneScope`.
+  - Ensures the demo scenes register globals and finalize runtime proxies correctly in player builds, including the additive scene flow.
 
 ## Version 1.0.2
 

--- a/Docs/docs/core-concepts/global-scope.md
+++ b/Docs/docs/core-concepts/global-scope.md
@@ -13,9 +13,11 @@ Saneject is mostly editor-time DI, but some runtime scenarios still need lookup 
 - `RuntimeProxy` can resolve through `FromGlobalScope()` for fast lookup.
 - You can also call `GlobalScope` directly as a service locator when needed.
 
+> ℹ️ `GlobalScope` is automatically cleared when returning to Edit Mode after Play Mode ends. This prevents stale global registrations from leaking into the next Play session when domain reload is disabled.
+
 ## What problem it solves
 
-Unity serialization cannot serialize direct references between certain boundaries: 
+Unity serialization cannot serialize direct references between certain boundaries:
 
 - Scene ↔ other scene
 - Scene ↔ prefab asset

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Lifecycle.meta
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Lifecycle.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 400bac3443b0474ea26daf193e0f24c8
+timeCreated: 1776666699

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Lifecycle/GlobalScopePlayModeReset.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Lifecycle/GlobalScopePlayModeReset.cs
@@ -1,0 +1,24 @@
+﻿using System.ComponentModel;
+using Plugins.Saneject.Runtime.Scopes;
+using UnityEditor;
+
+namespace Plugins.Saneject.Editor.Lifecycle
+{
+    [InitializeOnLoad, EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class GlobalScopePlayModeReset
+    {
+        static GlobalScopePlayModeReset()
+        {
+            EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+        }
+
+        private static void OnPlayModeStateChanged(PlayModeStateChange state)
+        {
+            if (state != PlayModeStateChange.EnteredEditMode)
+                return;
+
+            GlobalScope.ClearInternal();
+        }
+    }
+} 

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Lifecycle/GlobalScopePlayModeReset.cs.meta
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Lifecycle/GlobalScopePlayModeReset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ec0c7461e69e42558853113f1a4bdaea
+timeCreated: 1776666717

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Scopes/GlobalScope.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Scopes/GlobalScope.cs
@@ -1,13 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using Plugins.Saneject.Runtime.Settings;
 using UnityEngine;
+using Component = UnityEngine.Component;
 using Object = UnityEngine.Object;
 
 namespace Plugins.Saneject.Runtime.Scopes
 {
     /// <summary>
-    /// Static runtime registry and service locator for globally accessible <see cref="Component"/> instances.
+    /// Static runtime registry and service locator for globally accessible <see cref="UnityEngine.Component" /> instances.
     /// Stores one registration per concrete component type and is intended for Play Mode usage.
     /// </summary>
     public static class GlobalScope
@@ -114,7 +116,7 @@ namespace Plugins.Saneject.Runtime.Scopes
             component = GetComponent<T>();
             return component != null;
         }
-
+        
         /// <summary>
         /// Remove all registered global instances. Only valid in Play Mode.
         /// </summary>
@@ -123,11 +125,17 @@ namespace Plugins.Saneject.Runtime.Scopes
             if (!CheckModificationAllowed())
                 return;
 
-            Instances.Clear();
-            OwnerTypeMap.Clear();
+            ClearInternal();
 
             if (UserSettings.LogGlobalScopeRegistration)
                 Debug.Log("Saneject: GlobalScope cleared. All global registrations removed.");
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void ClearInternal()
+        {
+            Instances.Clear();
+            OwnerTypeMap.Clear();
         }
 
         private static bool CheckModificationAllowed()

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/Scenes/GameScene.unity
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/Scenes/GameScene.unity
@@ -545,7 +545,7 @@ MeshCollider:
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!114 &5541139865468942479
 MonoBehaviour:
-  m_ObjectHideFlags: 16
+  m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
@@ -724,7 +724,7 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7250975890217056285
 MonoBehaviour:
-  m_ObjectHideFlags: 16
+  m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/Scenes/UIScene.unity
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Samples~/DemoGame/Scenes/UIScene.unity
@@ -972,7 +972,7 @@ GameObject:
   m_IsActive: 1
 --- !u!114 &1801980456
 MonoBehaviour:
-  m_ObjectHideFlags: 16
+  m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
@@ -2,7 +2,7 @@
   "name": "com.alexanderlarsen.saneject",
   "author": "Alexander Larsen",
   "displayName": "Saneject",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Inject dependencies in the Unity Editor, not Play Mode, by writing them directly into serialized fields at edit-time using familiar DI APIs, so everything stays visible in the Inspector, including interfaces.\n\nNo runtime container. No startup cost. No hidden wiring. No weird lifecycles. Just simple, deterministic edit-time DI that works with Unity, not around it.",
   "documentationUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/README.md",
   "changelogUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/CHANGELOG.md",

--- a/UnityProject/Saneject/ProjectSettings/Saneject/ProjectSettings.json
+++ b/UnityProject/Saneject/ProjectSettings/Saneject/ProjectSettings.json
@@ -1,5 +1,6 @@
 {
-  "UseContextIsolation": true,
-  "GenerateProxyScriptsOnDomainReload": true,
-  "ProxyAssetGenerationFolder": "Assets/SanejectGenerated/RuntimeProxies"
+    "useContextIsolation": false,
+    "generateScopeNamespaceFromFolder": true,
+    "generateProxyScriptsOnDomainReload": true,
+    "proxyAssetGenerationFolder": "Assets/SanejectGenerated/RuntimeProxies"
 }


### PR DESCRIPTION
## Fixes

- Fixed `GlobalScope` persistence when domain reload is disabled.
  - Added an editor Play Mode lifecycle reset that clears `GlobalScope` on Enter Edit Mode after Play Mode exit.
  - Prevents stale global registrations from leaking into the next run.
  - Ensures `BindGlobal<T>()` and runtime proxy singleton registrations behave correctly regardless of domain reload settings.
- Fixed sample game player-build failures caused by legacy hide flags on shipped scopes.
  - Removed serialized `DontSaveInBuild` flags that remained on `PlayerScope`, `GameSceneScope`, and `UISceneScope`.
  - Ensures the demo scenes register globals and finalize runtime proxies correctly in player builds, including the additive scene flow.