### PR TITLE
Version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-- Fixed `ToTarget<T>` matching for inherited component targets. `.ToTarget<Base>()` now matches derived component types, and `.ToTarget<Derived>()` also applies to inherited injection members on the same derived component.
+- Fixed `ToTarget<T>` matching for inherited and nested targets. `.ToTarget<Base>()` now matches derived target types, `.ToTarget<Derived>()` also applies to inherited injection members on the same derived target, and nested serializable injection targets are matched by their nested owner type.
 - Fixed binding validation for duplicate or ambiguous qualifier combinations that could resolve the same injection site.
 
 ## Version 1.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-- Fixed `ToTarget<T>` matching for inherited component targets, so target qualifiers now match derived component types.
+- Fixed `ToTarget<T>` matching for inherited component targets. `.ToTarget<Base>()` now matches derived component types, and `.ToTarget<Derived>()` also applies to inherited injection members on the same derived component.
 - Fixed binding validation for duplicate or ambiguous qualifier combinations that could resolve the same injection site.
 
 ## Version 1.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ﻿# Changelog
 
+## Version 1.0.6
+
+### Fixes
+
+- Fixed `ToTarget<T>` matching for inherited component targets, so target qualifiers now match derived component types.
+- Fixed binding validation for duplicate or ambiguous qualifier combinations that could resolve the same injection site.
+
 ## Version 1.0.5
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 1.0.6
 
+### Changes
+
+- Updated ID matching so injection sites with an ID only match bindings with the same `ToID`.
+- Updated binding uniqueness detection so ID-qualified and non-ID-qualified bindings are distinct.
+
 ### Fixes
 
 - Fixed `ToTarget<T>` matching for inherited component targets, so target qualifiers now match derived component types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 ﻿# Changelog
 
-## Version 1.0.6
+## Version 1.1.0
 
 ### Changes
 
-- Updated ID matching so injection sites with an ID only match bindings with the same `ToID`.
-- Updated binding uniqueness detection so ID-qualified and non-ID-qualified bindings are distinct.
+- ID-qualified injection sites now require a matching `ToID(...)` binding. Unqualified bindings only match injection sites without an ID.
+- If an `[Inject("id")]` site previously relied on an unqualified binding, add `.ToID("id")` to the binding or remove the ID from the injection site.
 
 ### Fixes
 

--- a/Docs/docs/core-concepts/binding.md
+++ b/Docs/docs/core-concepts/binding.md
@@ -176,7 +176,8 @@ Binding qualifiers restrict which injection sites (fields, properties, methods) 
 Important behavior:
 
 - Binding qualifiers are additive, so all specified qualifiers must match.
-- If a binding qualifier is not set on the binding, the binding matches by `TInterface` or `TConcrete` only.
+- Injection sites without an ID match bindings without `ToID`. Injection sites with an ID only match bindings with the same `ToID`.
+- If `ToTarget` or `ToMember` is not set on the binding, that qualifier does not restrict where the binding applies.
 - `ToTarget<TTarget>()` matches the actual injection target component type. A binding targeted to a base component type also matches derived component types.
 - Binding qualifiers apply to component, asset, and runtime proxy bindings.
 - Binding qualifiers do not apply to global bindings.
@@ -247,9 +248,10 @@ Duplicate checks use these criteria:
 4. Same single/collection shape.
 5. Qualifier ambiguity:
     - If neither binding has qualifiers that separate it from the other, they conflict.
-    - Empty qualifier sets are unrestricted and do not separate bindings.
+    - `ToID` separates bindings by ID. A binding without `ToID` does not overlap a binding with `ToID`, and two bindings with `ToID` overlap only when their IDs overlap.
     - `ToTarget` qualifiers overlap when their target component type hierarchies overlap.
-    - `ToMember` and `ToID` qualifiers separate bindings only when both bindings specify non-overlapping values.
+    - `ToMember` qualifiers separate bindings only when both bindings specify non-overlapping values.
+    - Empty `ToTarget` and `ToMember` qualifier sets are unrestricted and do not separate bindings.
 
 Examples:
 
@@ -278,9 +280,20 @@ BindAsset<IGameConfig, GameConfigAsset>()
 ```
 
 ```csharp
-// Ambiguous: both bindings can resolve [Inject("menu")] members on MainMenuController.
+// Distinct: one binding matches ID "menu" and the other matches injection sites without an ID.
 BindAsset<IGameConfig, GameConfigAsset>()
     .ToID("menu")
+    .FromResources("Configs/Menu");
+
+BindAsset<IGameConfig, GameConfigAsset>()
+    .ToTarget<MainMenuController>()
+    .FromResources("Configs/Menu");
+```
+
+```csharp
+// Ambiguous: both bindings can resolve the config member on MainMenuController.
+BindAsset<IGameConfig, GameConfigAsset>()
+    .ToMember("config")
     .FromResources("Configs/Menu");
 
 BindAsset<IGameConfig, GameConfigAsset>()

--- a/Docs/docs/core-concepts/binding.md
+++ b/Docs/docs/core-concepts/binding.md
@@ -40,8 +40,8 @@ Most bindings follow this general pattern or a combination of these:
 ```csharp
 BindComponent<IAudioService, AudioManager>()
     .ToID("hud") // Optional qualifier that matches [Inject("hud")]
-    .ToTarget<CombatHud>() // Optional qualifier that matches injection targets of type CombatHud
-    .ToMember("audioService") // Optional qualifier that matches and methods named "audioService"
+    .ToTarget<CombatHud>() // Optional qualifier that matches injection target objects of type CombatHud
+    .ToMember("audioService") // Optional qualifier that matches members named "audioService"
     .FromTargetSelf() // Required locator strategy that looks for the AudioManager on the transform of the CombatHud
     .WhereComponent(c => c.isActiveAndEnabled); // Optional filter that only includes enabled components
 ```
@@ -170,7 +170,7 @@ Binding qualifiers restrict which injection sites (fields, properties, methods) 
 | Qualifier                    | Injection site match                                                            |
 |------------------------------|---------------------------------------------------------------------------------|
 | `ToID("someId")`             | Fields, properties, methods marked with `[Inject("someId")]`                    |
-| `ToTarget<TTarget>()`        | Fields, properties, methods on `TTarget` components and derived component types |
+| `ToTarget<TTarget>()`        | Fields, properties, methods owned by `TTarget` objects and derived types        |
 | `ToMember("someMemberName")` | Fields, properties, methods with name `"someMemberName"`                        |
 
 Important behavior:
@@ -178,7 +178,7 @@ Important behavior:
 - Binding qualifiers are additive, so all specified qualifiers must match.
 - Injection sites without an ID match bindings without `ToID`. Injection sites with an ID only match bindings with the same `ToID`.
 - If `ToTarget` or `ToMember` is not set on the binding, that qualifier does not restrict where the binding applies.
-- `ToTarget<TTarget>()` matches the actual injection target component type. A binding targeted to a base component type also matches derived component types.
+- `ToTarget<TTarget>()` matches the actual object that owns the injected member. This can be a component or a nested serializable object, and a binding targeted to a base type also matches derived types.
 - Binding qualifiers apply to component, asset, and runtime proxy bindings.
 - Binding qualifiers do not apply to global bindings.
 
@@ -249,7 +249,7 @@ Duplicate and ambiguity checks use these criteria:
 5. Qualifier ambiguity:
    - If the criteria above do not separate two bindings, they conflict unless at least one qualifier rule below separates them.
    - `ToID` separates bindings by ID. A binding without `ToID` does not overlap a binding with `ToID`, and two bindings with `ToID` overlap only when their IDs overlap.
-   - `ToTarget` qualifiers overlap when their target component type hierarchies overlap.
+    - `ToTarget` qualifiers overlap when their target type hierarchies overlap.
    - `ToMember` qualifiers separate bindings only when both bindings specify non-overlapping values.
    - Empty `ToTarget` and `ToMember` qualifier sets are unrestricted and do not separate bindings.
 

--- a/Docs/docs/core-concepts/binding.md
+++ b/Docs/docs/core-concepts/binding.md
@@ -167,16 +167,17 @@ Full runtime proxy API:
 
 Binding qualifiers restrict which injection sites (fields, properties, methods) can be resolved from a binding.
 
-| Qualifier                    | Injection site match                                          |
-|------------------------------|---------------------------------------------------------------|
-| `ToID("someId")`             | Fields, properties, methods marked with `[Inject("someId")]`  |
-| `ToTarget<TTarget>()`        | Fields, properties, methods declared in a `TTarget` component |
-| `ToMember("someMemberName")` | Fields, properties, methods with name `"someMemberName"`      |
+| Qualifier                    | Injection site match                                                            |
+|------------------------------|---------------------------------------------------------------------------------|
+| `ToID("someId")`             | Fields, properties, methods marked with `[Inject("someId")]`                    |
+| `ToTarget<TTarget>()`        | Fields, properties, methods on `TTarget` components and derived component types |
+| `ToMember("someMemberName")` | Fields, properties, methods with name `"someMemberName"`                        |
 
 Important behavior:
 
 - Binding qualifiers are additive, so all specified qualifiers must match.
 - If a binding qualifier is not set on the binding, the binding matches by `TInterface` or `TConcrete` only.
+- `ToTarget<TTarget>()` matches the actual injection target component type. A binding targeted to a base component type also matches derived component types.
 - Binding qualifiers apply to component, asset, and runtime proxy bindings.
 - Binding qualifiers do not apply to global bindings.
 
@@ -223,18 +224,18 @@ protected override void DeclareBindings()
 }
 ```
 
-| Binding Family                | Filter Support                                                                             |
-|--------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
-| Component bindings         | Yes                                                                                        |
-| Asset bindings                 | Yes                                                                                        |
-| Global bindings                      | Yes (same filter API as component bindings). |
-| Runtime proxy bindings | No                                                                                         |
+| Binding Family         | Filter Support                               |
+|------------------------|----------------------------------------------|
+| Component bindings     | Yes                                          |
+| Asset bindings         | Yes                                          |
+| Global bindings        | Yes (same filter API as component bindings). |
+| Runtime proxy bindings | No                                           |
 
 If a binding filter throws an exception, Saneject logs a binding filter error for that binding.
 
 ## Binding uniqueness
 
-Saneject enforces binding unique within each `Scope`. When a binding is considered duplicate, Saneject logs an error and excludes the duplicate from the injection run.
+Saneject enforces unambiguous bindings within each `Scope`. When two bindings are considered duplicate or ambiguous, Saneject logs an error and excludes the conflicting binding from the injection run.
 
 Duplicate checks use these criteria:
 
@@ -244,14 +245,16 @@ Duplicate checks use these criteria:
     - `TInterface` when present.
     - Otherwise `TConcrete`.
 4. Same single/collection shape.
-5. Qualifier overlap:
-    - If both bindings have no binding qualifiers at all, they conflict.
-    - Otherwise, conflict requires full overlap in `ToTarget`, `ToMember`, and `ToID` simultaneously.
+5. Qualifier ambiguity:
+    - If neither binding has qualifiers that separate it from the other, they conflict.
+    - Empty qualifier sets are unrestricted and do not separate bindings.
+    - `ToTarget` qualifiers overlap when their target component type hierarchies overlap.
+    - `ToMember` and `ToID` qualifiers separate bindings only when both bindings specify non-overlapping values.
 
 Examples:
 
 ```csharp
-// Duplicate: same scope, same family, same type, same shape, no qualifiers.
+// Duplicate or ambiguous: same scope, same family, same type, same shape, no qualifiers.
 BindComponent<AudioManager>()
     .FromScopeSelf();
 
@@ -272,6 +275,17 @@ BindAsset<IGameConfig, GameConfigAsset>()
     .ToMember("config")
     .ToID("gameplay")
     .FromResources("Configs/Gameplay");
+```
+
+```csharp
+// Ambiguous: both bindings can resolve [Inject("menu")] members on MainMenuController.
+BindAsset<IGameConfig, GameConfigAsset>()
+    .ToID("menu")
+    .FromResources("Configs/Menu");
+
+BindAsset<IGameConfig, GameConfigAsset>()
+    .ToTarget<MainMenuController>()
+    .FromResources("Configs/Menu");
 ```
 
 Global bindings have an extra rule: only one global binding per concrete component type is allowed across active

--- a/Docs/docs/core-concepts/binding.md
+++ b/Docs/docs/core-concepts/binding.md
@@ -238,7 +238,7 @@ If a binding filter throws an exception, Saneject logs a binding filter error fo
 
 Saneject enforces unambiguous bindings within each `Scope`. When two bindings are considered duplicate or ambiguous, Saneject logs an error and excludes the conflicting binding from the injection run.
 
-Duplicate checks use these criteria:
+Duplicate and ambiguity checks use these criteria:
 
 1. Same scope.
 2. Same binding family (`ComponentBindingNode`, `AssetBindingNode`, or `GlobalComponentBindingNode`).
@@ -247,11 +247,11 @@ Duplicate checks use these criteria:
     - Otherwise `TConcrete`.
 4. Same single/collection shape.
 5. Qualifier ambiguity:
-    - If neither binding has qualifiers that separate it from the other, they conflict.
-    - `ToID` separates bindings by ID. A binding without `ToID` does not overlap a binding with `ToID`, and two bindings with `ToID` overlap only when their IDs overlap.
-    - `ToTarget` qualifiers overlap when their target component type hierarchies overlap.
-    - `ToMember` qualifiers separate bindings only when both bindings specify non-overlapping values.
-    - Empty `ToTarget` and `ToMember` qualifier sets are unrestricted and do not separate bindings.
+   - If the criteria above do not separate two bindings, they conflict unless at least one qualifier rule below separates them.
+   - `ToID` separates bindings by ID. A binding without `ToID` does not overlap a binding with `ToID`, and two bindings with `ToID` overlap only when their IDs overlap.
+   - `ToTarget` qualifiers overlap when their target component type hierarchies overlap.
+   - `ToMember` qualifiers separate bindings only when both bindings specify non-overlapping values.
+   - Empty `ToTarget` and `ToMember` qualifier sets are unrestricted and do not separate bindings.
 
 Examples:
 

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Core/BindingValidator.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Core/BindingValidator.cs
@@ -43,7 +43,7 @@ namespace Plugins.Saneject.Editor.Core
                 errors.Add(new InvalidBindingError
                 (
                     bindingNode: bindingNode,
-                    reason: "Duplicate binding within same Scope detected"
+                    reason: "Duplicate or ambiguous binding within same Scope detected"
                 ));
 
             switch (bindingNode)

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Core/Resolver.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Core/Resolver.cs
@@ -7,6 +7,7 @@ using Plugins.Saneject.Editor.Data.Errors;
 using Plugins.Saneject.Editor.Data.Graph;
 using Plugins.Saneject.Editor.Data.Graph.Nodes;
 using Plugins.Saneject.Editor.Data.Injection;
+using UnityEngine;
 using Object = UnityEngine.Object;
 
 namespace Plugins.Saneject.Editor.Core
@@ -18,9 +19,23 @@ namespace Plugins.Saneject.Editor.Core
             InjectionContext context,
             InjectionProgressTracker progressTracker)
         {
-            ResolveGlobals(context, progressTracker);
-            ResolveFields(context, progressTracker);
-            ResolveMethods(context, progressTracker);
+            ResolveGlobals
+            (
+                context,
+                progressTracker
+            );
+
+            ResolveFields
+            (
+                context,
+                progressTracker
+            );
+
+            ResolveMethods
+            (
+                context,
+                progressTracker
+            );
         }
 
         private static void ResolveGlobals(
@@ -49,16 +64,28 @@ namespace Plugins.Saneject.Editor.Core
                 );
 
                 if (candidates is not { Length: > 0 })
-                    context.RegisterError(new MissingGlobalDependencyError
+                    context.RegisterError
                     (
-                        binding,
-                        rejectedTypes
-                    ));
+                        new MissingGlobalDependencyError
+                        (
+                            binding,
+                            rejectedTypes
+                        )
+                    );
 
-                if (!globalMap.TryGetValue(binding.ScopeNode, out HashSet<object> dependencySet))
+                if (!globalMap.TryGetValue
+                    (
+                        binding.ScopeNode,
+                        out HashSet<object> dependencySet
+                    ))
                 {
                     dependencySet = new HashSet<object>();
-                    globalMap.Add(binding.ScopeNode, dependencySet);
+
+                    globalMap.Add
+                    (
+                        binding.ScopeNode,
+                        dependencySet
+                    );
                 }
 
                 object resolved = candidates.FirstOrDefault();
@@ -68,7 +95,11 @@ namespace Plugins.Saneject.Editor.Core
             }
 
             foreach ((ScopeNode scopeNode, HashSet<object> dependencies) in globalMap)
-                context.RegisterGlobalDependencies(scopeNode, dependencies);
+                context.RegisterGlobalDependencies
+                (
+                    scopeNode,
+                    dependencies
+                );
         }
 
         private static void ResolveFields(
@@ -85,7 +116,13 @@ namespace Plugins.Saneject.Editor.Core
             foreach (FieldNode fieldNode in fieldNodes)
             {
                 progressTracker.UpdateInfoText($"Resolving field: {fieldNode.ShortPath}");
-                ResolveField(fieldNode, context);
+
+                ResolveField
+                (
+                    fieldNode,
+                    context
+                );
+
                 progressTracker.NextStep();
             }
         }
@@ -104,7 +141,13 @@ namespace Plugins.Saneject.Editor.Core
             foreach (MethodNode methodNode in methodNodes)
             {
                 progressTracker.UpdateInfoText($"Resolving method: {methodNode.ShortPath}");
-                ResolveMethod(methodNode, context);
+
+                ResolveMethod
+                (
+                    methodNode,
+                    context
+                );
+
                 progressTracker.NextStep();
             }
         }
@@ -117,7 +160,7 @@ namespace Plugins.Saneject.Editor.Core
             (
                 currentScope: fieldNode.ComponentNode.TransformNode.NearestScopeNode,
                 context: context,
-                declaringType: fieldNode.DeclaringType,
+                componentType: fieldNode.ComponentNode.Component.GetType(),
                 requestedType: fieldNode.RequestedType,
                 isCollection: fieldNode.IsCollection,
                 qualifyingMemberName: fieldNode.QualifyingName,
@@ -144,12 +187,15 @@ namespace Plugins.Saneject.Editor.Core
                 );
 
                 if (candidates is not { Length: > 0 })
-                    context.RegisterError(new MissingDependencyError
+                    context.RegisterError
                     (
-                        bindingNode,
-                        fieldNode,
-                        rejectedTypes
-                    ));
+                        new MissingDependencyError
+                        (
+                            bindingNode,
+                            fieldNode,
+                            rejectedTypes
+                        )
+                    );
 
                 resolved = ResolveCandidates
                 (
@@ -162,7 +208,11 @@ namespace Plugins.Saneject.Editor.Core
                 context.RegisterUsedBinding(bindingNode);
             }
 
-            context.RegisterFieldDependency(fieldNode, resolved);
+            context.RegisterFieldDependency
+            (
+                fieldNode,
+                resolved
+            );
         }
 
         private static void ResolveMethod(
@@ -177,7 +227,7 @@ namespace Plugins.Saneject.Editor.Core
                 (
                     currentScope: methodNode.ComponentNode.TransformNode.NearestScopeNode,
                     context: context,
-                    declaringType: methodNode.DeclaringType,
+                    componentType: methodNode.ComponentNode.Component.GetType(),
                     requestedType: parameterNode.RequestedType,
                     isCollection: parameterNode.IsCollection,
                     qualifyingMemberName: methodNode.QualifyingName,
@@ -204,12 +254,15 @@ namespace Plugins.Saneject.Editor.Core
                     );
 
                     if (candidates is not { Length: > 0 })
-                        context.RegisterError(new MissingDependencyError
+                        context.RegisterError
                         (
-                            bindingNode,
-                            parameterNode,
-                            rejectedTypes
-                        ));
+                            new MissingDependencyError
+                            (
+                                bindingNode,
+                                parameterNode,
+                                rejectedTypes
+                            )
+                        );
 
                     resolved = ResolveCandidates
                     (
@@ -224,13 +277,17 @@ namespace Plugins.Saneject.Editor.Core
                 context.RegisterUsedBinding(bindingNode);
             }
 
-            context.RegisterMethodDependencies(methodNode, resolvedParameters);
+            context.RegisterMethodDependencies
+            (
+                methodNode,
+                resolvedParameters
+            );
         }
 
         private static BindingNode FindMatchingBindingNode(
             ScopeNode currentScope,
             InjectionContext context,
-            Type declaringType,
+            Type componentType,
             Type requestedType,
             bool isCollection,
             string qualifyingMemberName,
@@ -275,9 +332,9 @@ namespace Plugins.Saneject.Editor.Core
             }
 
             bool MatchesTargetTypeQualifiers(BindingNode bindingNode)
-            {
+            { 
                 return bindingNode.TargetTypeQualifiers.Count == 0 ||
-                       bindingNode.TargetTypeQualifiers.Contains(declaringType);
+                    bindingNode.TargetTypeQualifiers.Any(t => t.IsAssignableFrom(componentType));
             }
 
             bool MatchesMemberNameQualifiers(BindingNode bindingNode)
@@ -311,10 +368,18 @@ namespace Plugins.Saneject.Editor.Core
 
                 case TypeShape.Array:
                 {
-                    Array array = Array.CreateInstance(requestedType, candidates.Length);
+                    Array array = Array.CreateInstance
+                    (
+                        requestedType,
+                        candidates.Length
+                    );
 
                     for (int i = 0; i < candidates.Length; i++)
-                        array.SetValue(candidates[i], i);
+                        array.SetValue
+                        (
+                            candidates[i],
+                            i
+                        );
 
                     return array;
                 }

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Core/Resolver.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Core/Resolver.cs
@@ -159,7 +159,7 @@ namespace Plugins.Saneject.Editor.Core
             (
                 currentScope: fieldNode.ComponentNode.TransformNode.NearestScopeNode,
                 context: context,
-                componentType: fieldNode.ComponentNode.Component.GetType(),
+                targetType: fieldNode.Owner.GetType(),
                 requestedType: fieldNode.RequestedType,
                 isCollection: fieldNode.IsCollection,
                 qualifyingMemberName: fieldNode.QualifyingName,
@@ -226,7 +226,7 @@ namespace Plugins.Saneject.Editor.Core
                 (
                     currentScope: methodNode.ComponentNode.TransformNode.NearestScopeNode,
                     context: context,
-                    componentType: methodNode.ComponentNode.Component.GetType(),
+                    targetType: methodNode.Owner.GetType(),
                     requestedType: parameterNode.RequestedType,
                     isCollection: parameterNode.IsCollection,
                     qualifyingMemberName: methodNode.QualifyingName,
@@ -286,7 +286,7 @@ namespace Plugins.Saneject.Editor.Core
         private static BindingNode FindMatchingBindingNode(
             ScopeNode currentScope,
             InjectionContext context,
-            Type componentType,
+            Type targetType,
             Type requestedType,
             bool isCollection,
             string qualifyingMemberName,
@@ -333,7 +333,7 @@ namespace Plugins.Saneject.Editor.Core
             bool MatchesTargetTypeQualifiers(BindingNode bindingNode)
             {
                 return bindingNode.TargetTypeQualifiers.Count == 0 ||
-                       bindingNode.TargetTypeQualifiers.Any(t => t.IsAssignableFrom(componentType));
+                       bindingNode.TargetTypeQualifiers.Any(t => t.IsAssignableFrom(targetType));
             }
 
             bool MatchesMemberNameQualifiers(BindingNode bindingNode)

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Core/Resolver.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Core/Resolver.cs
@@ -7,7 +7,6 @@ using Plugins.Saneject.Editor.Data.Errors;
 using Plugins.Saneject.Editor.Data.Graph;
 using Plugins.Saneject.Editor.Data.Graph.Nodes;
 using Plugins.Saneject.Editor.Data.Injection;
-using UnityEngine;
 using Object = UnityEngine.Object;
 
 namespace Plugins.Saneject.Editor.Core
@@ -332,9 +331,9 @@ namespace Plugins.Saneject.Editor.Core
             }
 
             bool MatchesTargetTypeQualifiers(BindingNode bindingNode)
-            { 
+            {
                 return bindingNode.TargetTypeQualifiers.Count == 0 ||
-                    bindingNode.TargetTypeQualifiers.Any(t => t.IsAssignableFrom(componentType));
+                       bindingNode.TargetTypeQualifiers.Any(t => t.IsAssignableFrom(componentType));
             }
 
             bool MatchesMemberNameQualifiers(BindingNode bindingNode)
@@ -345,8 +344,10 @@ namespace Plugins.Saneject.Editor.Core
 
             bool MatchesIdQualifiers(BindingNode bindingNode)
             {
-                return bindingNode.IdQualifiers.Count == 0 ||
-                       bindingNode.IdQualifiers.Contains(injectId);
+                if (!string.IsNullOrWhiteSpace(injectId))
+                    return bindingNode.IdQualifiers.Count > 0 && bindingNode.IdQualifiers.Contains(injectId);
+
+                return bindingNode.IdQualifiers.Count == 0;
             }
         }
 

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Data/Graph/Nodes/BindingNode.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Data/Graph/Nodes/BindingNode.cs
@@ -82,7 +82,8 @@ namespace Plugins.Saneject.Editor.Data.Graph.Nodes
                 other.MemberNameQualifiers.Count > 0 &&
                 !MemberNameQualifiers.OverlapsWith(other.MemberNameQualifiers);
 
-            bool separatedById = !IdQualifiers.OverlapsWith(other.IdQualifiers);
+            bool separatedById = (IdQualifiers.Count > 0 || other.IdQualifiers.Count > 0) && 
+                                 !IdQualifiers.OverlapsWith(other.IdQualifiers);
 
             return !separatedByTarget
                    && !separatedByMemberName

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Data/Graph/Nodes/BindingNode.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Data/Graph/Nodes/BindingNode.cs
@@ -82,10 +82,7 @@ namespace Plugins.Saneject.Editor.Data.Graph.Nodes
                 other.MemberNameQualifiers.Count > 0 &&
                 !MemberNameQualifiers.OverlapsWith(other.MemberNameQualifiers);
 
-            bool separatedById =
-                IdQualifiers.Count > 0 &&
-                other.IdQualifiers.Count > 0 &&
-                !IdQualifiers.OverlapsWith(other.IdQualifiers);
+            bool separatedById = !IdQualifiers.OverlapsWith(other.IdQualifiers);
 
             return !separatedByTarget
                    && !separatedByMemberName

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Data/Graph/Nodes/BindingNode.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Data/Graph/Nodes/BindingNode.cs
@@ -47,32 +47,49 @@ namespace Plugins.Saneject.Editor.Data.Graph.Nodes
             if (other is null)
                 return false;
 
-            if (ReferenceEquals(this, other))
+            if (ReferenceEquals
+                (
+                    this,
+                    other
+                ))
                 return true;
 
-            if (!Equals(ScopeNode, other.ScopeNode))
+            if (!Equals
+                (
+                    ScopeNode,
+                    other.ScopeNode
+                ))
                 return false;
 
             if (other.GetType() != GetType())
                 return false;
 
-            if (InterfaceType != null ? InterfaceType != other.InterfaceType : ConcreteType != other.ConcreteType)
+            if (InterfaceType != null
+                    ? InterfaceType != other.InterfaceType
+                    : ConcreteType != other.ConcreteType)
                 return false;
 
             if (IsCollectionBinding != other.IsCollectionBinding)
                 return false;
 
-            if (TargetTypeQualifiers.Count == 0
-                && MemberNameQualifiers.Count == 0
-                && IdQualifiers.Count == 0
-                && other.TargetTypeQualifiers.Count == 0
-                && other.MemberNameQualifiers.Count == 0
-                && other.IdQualifiers.Count == 0)
-                return true;
+            bool separatedByTarget =
+                TargetTypeQualifiers.Count > 0 &&
+                other.TargetTypeQualifiers.Count > 0 &&
+                !TargetTypeQualifiers.OverlapsWith(other.TargetTypeQualifiers);
 
-            return TargetTypeQualifiers.OverlapsWith(other.TargetTypeQualifiers)
-                   && MemberNameQualifiers.OverlapsWith(other.MemberNameQualifiers)
-                   && IdQualifiers.OverlapsWith(other.IdQualifiers);
+            bool separatedByMemberName =
+                MemberNameQualifiers.Count > 0 &&
+                other.MemberNameQualifiers.Count > 0 &&
+                !MemberNameQualifiers.OverlapsWith(other.MemberNameQualifiers);
+
+            bool separatedById =
+                IdQualifiers.Count > 0 &&
+                other.IdQualifiers.Count > 0 &&
+                !IdQualifiers.OverlapsWith(other.IdQualifiers);
+
+            return !separatedByTarget
+                   && !separatedByMemberName
+                   && !separatedById;
         }
 
         public override bool Equals(object obj)
@@ -87,10 +104,7 @@ namespace Plugins.Saneject.Editor.Data.Graph.Nodes
                 ScopeNode,
                 GetType(),
                 InterfaceType ?? ConcreteType,
-                IsCollectionBinding,
-                TargetTypeQualifiers.Count > 0,
-                MemberNameQualifiers.Count > 0,
-                IdQualifiers.Count > 0
+                IsCollectionBinding
             );
         }
     }

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Data/Graph/Nodes/MemberNode.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Data/Graph/Nodes/MemberNode.cs
@@ -19,7 +19,6 @@ namespace Plugins.Saneject.Editor.Data.Graph.Nodes
         {
             Owner = owner;
             ComponentNode = componentNode;
-            DeclaringType = memberInfo.DeclaringType;
             QualifyingName = NameUtility.GetLogicalName(memberInfo.Name);
             InjectId = injectAttribute.ID;
             SuppressMissingErrors = injectAttribute.SuppressMissingErrors;
@@ -29,7 +28,6 @@ namespace Plugins.Saneject.Editor.Data.Graph.Nodes
 
         public object Owner { get; }
         public ComponentNode ComponentNode { get; }
-        public Type DeclaringType { get; }
         public string QualifyingName { get; }
         public string InjectId { get; }
         public bool SuppressMissingErrors { get; }

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Extensions/EnumerableOverlapExtensions.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Extensions/EnumerableOverlapExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+
 // ReSharper disable ForeachCanBeConvertedToQueryUsingAnotherGetEnumerator
 
 namespace Plugins.Saneject.Editor.Extensions
@@ -28,8 +29,17 @@ namespace Plugins.Saneject.Editor.Extensions
             this IEnumerable<string> a,
             IEnumerable<string> b)
         {
-            HashSet<string> aSet = new(a.Where(s => !string.IsNullOrWhiteSpace(s)), StringComparer.Ordinal);
-            HashSet<string> bSet = new(b.Where(s => !string.IsNullOrWhiteSpace(s)), StringComparer.Ordinal);
+            HashSet<string> aSet = new
+            (
+                a.Where(s => !string.IsNullOrWhiteSpace(s)),
+                StringComparer.Ordinal
+            );
+
+            HashSet<string> bSet = new
+            (
+                b.Where(s => !string.IsNullOrWhiteSpace(s)),
+                StringComparer.Ordinal
+            );
 
             foreach (string id in aSet)
                 if (bSet.Contains(id))

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Attributes/InjectAttribute.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Attributes/InjectAttribute.cs
@@ -49,7 +49,7 @@ namespace Plugins.Saneject.Runtime.Attributes
         /// <summary>
         /// Marks the field or method for injection with an ID while optionally suppressing missing binding and missing dependency logs for the field.
         /// </summary>
-        /// <param name="id">The binding ID to match against.</param>
+        /// <param name="id">The binding ID to match against. Only bindings with the same ID will be used for resolution.</param>
         /// <param name="suppressMissingErrors">
         /// If <c>true</c>, suppresses error logs when no binding or dependency is found.
         /// </param>

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Attributes/InjectAttribute.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Attributes/InjectAttribute.cs
@@ -16,10 +16,10 @@ namespace Plugins.Saneject.Runtime.Attributes
     public sealed class InjectAttribute : PropertyAttribute
     {
         /// <summary>
-        /// Marks the field or method for injection, using only type-based binding resolution.
+        /// Marks the field or method for injection without an ID.
         /// </summary>
         /// <remarks>
-        /// The dependency is resolved by matching the member's type against bindings in the scope hierarchy.
+        /// The dependency is resolved by matching the member's type against bindings in the scope hierarchy that do not specify an ID.
         /// </remarks>
         public InjectAttribute()
         {
@@ -62,7 +62,7 @@ namespace Plugins.Saneject.Runtime.Attributes
         }
 
         /// <summary>
-        /// Gets the binding ID used for dependency resolution, or <c>null</c> if only type-based resolution is used.
+        /// Gets the binding ID used for dependency resolution, or <c>null</c> if bindings without an ID should be used.
         /// </summary>
         public string ID { get; }
 

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Bindings/Asset/AssetBindingBuilder.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Bindings/Asset/AssetBindingBuilder.cs
@@ -75,8 +75,8 @@ namespace Plugins.Saneject.Runtime.Bindings.Asset
         }
 
         /// <summary>
-        /// Qualifies this binding to apply only when the injection target is of the given type.
-        /// The injection target is the <see cref="Component" /> that owns the field or property
+        /// Qualifies this binding to apply only when the injection target is of the given type or a derived type.
+        /// The injection target is the <see cref="Component" /> that owns the field, property, or method
         /// marked with <see cref="Attributes.InjectAttribute" />.
         /// </summary>
         /// <typeparam name="TTarget">The target type this binding applies to.</typeparam>
@@ -88,8 +88,8 @@ namespace Plugins.Saneject.Runtime.Bindings.Asset
         }
 
         /// <summary>
-        /// Qualifies this binding to apply only when the injection target is one of the specified types.
-        /// The injection target is the <see cref="Component" /> that owns the field or property
+        /// Qualifies this binding to apply only when the injection target is one of the specified types or a derived type.
+        /// The injection target is the <see cref="Component" /> that owns the field, property, or method
         /// marked with <see cref="Attributes.InjectAttribute" />.
         /// </summary>
         /// <param name="targetTypes">One or more target <see cref="Type" /> objects to match against.</param>
@@ -101,10 +101,10 @@ namespace Plugins.Saneject.Runtime.Bindings.Asset
         }
 
         /// <summary>
-        /// Qualifies this binding to apply only when the injection target member (field or property)
+        /// Qualifies this binding to apply only when the injection target member (field, property, or method)
         /// has one of the specified names.
         /// </summary>
-        /// <param name="memberNames">The field or property names on the injection target that this binding should apply to.</param>
+        /// <param name="memberNames">The field, property, or method names on the injection target that this binding should apply to.</param>
         /// <returns>The builder instance for fluent chaining.</returns>
         public AssetBindingBuilder<TAsset> ToMember(params string[] memberNames)
         {

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Bindings/Asset/AssetBindingBuilder.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Bindings/Asset/AssetBindingBuilder.cs
@@ -63,11 +63,10 @@ namespace Plugins.Saneject.Runtime.Bindings.Asset
         #region QUALIFIER METHODS
 
         /// <summary>
-        /// Qualifies this binding with an ID.
-        /// Only injection targets annotated with <see cref="Attributes.InjectAttribute" />
+        /// Only injection sites annotated with <see cref="Attributes.InjectAttribute" />
         /// that specify the same ID will resolve using this binding.
         /// </summary>
-        /// <param name="ids">The identifiers to match against injection targets.</param>
+        /// <param name="ids">The identifiers to match against injection sites.</param>
         /// <returns>The builder instance for fluent chaining.</returns>
         public AssetBindingBuilder<TAsset> ToID(params string[] ids)
         {

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Bindings/Asset/AssetBindingBuilder.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Bindings/Asset/AssetBindingBuilder.cs
@@ -76,7 +76,7 @@ namespace Plugins.Saneject.Runtime.Bindings.Asset
 
         /// <summary>
         /// Qualifies this binding to apply only when the injection target is of the given type or a derived type.
-        /// The injection target is the <see cref="Component" /> that owns the field, property, or method
+        /// The injection target is the object that owns the field, property, or method
         /// marked with <see cref="Attributes.InjectAttribute" />.
         /// </summary>
         /// <typeparam name="TTarget">The target type this binding applies to.</typeparam>
@@ -89,7 +89,7 @@ namespace Plugins.Saneject.Runtime.Bindings.Asset
 
         /// <summary>
         /// Qualifies this binding to apply only when the injection target is one of the specified types or a derived type.
-        /// The injection target is the <see cref="Component" /> that owns the field, property, or method
+        /// The injection target is the object that owns the field, property, or method
         /// marked with <see cref="Attributes.InjectAttribute" />.
         /// </summary>
         /// <param name="targetTypes">One or more target <see cref="Type" /> objects to match against.</param>

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Bindings/Component/ComponentBindingBuilder.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Bindings/Component/ComponentBindingBuilder.cs
@@ -49,8 +49,7 @@ namespace Plugins.Saneject.Runtime.Bindings.Component
         #region QUALIFIER METHODS
 
         /// <summary>
-        /// Qualifies this binding with one or more IDs.
-        /// Only injection sites (fields/properties/methods) annotated with an <see cref="Attributes.InjectAttribute" />
+        /// Only injection sites annotated with <see cref="Attributes.InjectAttribute" />
         /// that specify the same ID will resolve using this binding.
         /// </summary>
         /// <param name="ids">The identifiers to match against injection sites.</param>

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Bindings/Component/ComponentBindingBuilder.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Bindings/Component/ComponentBindingBuilder.cs
@@ -62,7 +62,7 @@ namespace Plugins.Saneject.Runtime.Bindings.Component
 
         /// <summary>
         /// Qualifies this binding to apply only when the injection target is of the given type or a derived type.
-        /// The injection target is the <see cref="UnityEngine.Component" /> that owns the field, property or method
+        /// The injection target is the object that owns the field, property or method
         /// marked with <see cref="Attributes.InjectAttribute" />.
         /// </summary>
         /// <typeparam name="TTarget">The target type this binding applies to.</typeparam>
@@ -75,7 +75,7 @@ namespace Plugins.Saneject.Runtime.Bindings.Component
 
         /// <summary>
         /// Qualifies this binding to apply only when the injection target is one of the specified types or a derived type.
-        /// The injection target is the <see cref="UnityEngine.Component" /> that owns the field, property or method
+        /// The injection target is the object that owns the field, property or method
         /// marked with <see cref="Attributes.InjectAttribute" />.
         /// </summary>
         /// <param name="targetTypes">One or more target <see cref="Type" /> objects to match against.</param>

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Bindings/Component/ComponentBindingBuilder.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Runtime/Bindings/Component/ComponentBindingBuilder.cs
@@ -61,7 +61,7 @@ namespace Plugins.Saneject.Runtime.Bindings.Component
         }
 
         /// <summary>
-        /// Qualifies this binding to apply only when the injection target is of the given type.
+        /// Qualifies this binding to apply only when the injection target is of the given type or a derived type.
         /// The injection target is the <see cref="UnityEngine.Component" /> that owns the field, property or method
         /// marked with <see cref="Attributes.InjectAttribute" />.
         /// </summary>
@@ -74,7 +74,7 @@ namespace Plugins.Saneject.Runtime.Bindings.Component
         }
 
         /// <summary>
-        /// Qualifies this binding to apply only when the injection target is one of the specified types.
+        /// Qualifies this binding to apply only when the injection target is one of the specified types or a derived type.
         /// The injection target is the <see cref="UnityEngine.Component" /> that owns the field, property or method
         /// marked with <see cref="Attributes.InjectAttribute" />.
         /// </summary>
@@ -87,9 +87,9 @@ namespace Plugins.Saneject.Runtime.Bindings.Component
         }
 
         /// <summary>
-        /// Qualifies this binding to apply only when the injection target member (field or property) has one of the specified names.
+        /// Qualifies this binding to apply only when the injection target member (field, property, or method) has one of the specified names.
         /// </summary>
-        /// <param name="memberNames">The field or property names on the injection target that this binding should apply to.</param>
+        /// <param name="memberNames">The field, property, or method names on the injection target that this binding should apply to.</param>
         /// <returns>The builder instance for fluent chaining.</returns>
         public ComponentBindingBuilder<TComponent> ToMember(params string[] memberNames)
         {

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
@@ -2,7 +2,7 @@
   "name": "com.alexanderlarsen.saneject",
   "author": "Alexander Larsen",
   "displayName": "Saneject",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Inject dependencies in the Unity Editor, not Play Mode, by writing them directly into serialized fields at edit-time using familiar DI APIs, so everything stays visible in the Inspector, including interfaces.\n\nNo runtime container. No startup cost. No hidden wiring. No weird lifecycles. Just simple, deterministic edit-time DI that works with Unity, not around it.",
   "documentationUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/README.md",
   "changelogUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/CHANGELOG.md",

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
@@ -2,7 +2,7 @@
   "name": "com.alexanderlarsen.saneject",
   "author": "Alexander Larsen",
   "displayName": "Saneject",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Inject dependencies in the Unity Editor, not Play Mode, by writing them directly into serialized fields at edit-time using familiar DI APIs, so everything stays visible in the Inspector, including interfaces.\n\nNo runtime container. No startup cost. No hidden wiring. No weird lifecycles. Just simple, deterministic edit-time DI that works with Unity, not around it.",
   "documentationUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/README.md",
   "changelogUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/CHANGELOG.md",

--- a/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Binding/Equality/BindingNodeEqualityTests.cs
+++ b/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Binding/Equality/BindingNodeEqualityTests.cs
@@ -186,7 +186,57 @@ namespace Tests.Saneject.Editor.Binding.Equality
         }
 
         [Test]
-        public void BindingNode_SameScope_TConcrete_WithIDAndTargetQualifiers_IsEqual()
+        public void BindingNode_SameScope_TConcrete_WithOnlyOverlappingIDQualifiers_IsEqual()
+        {
+            // Set up scene
+            TestScene scene = TestScene.Create(roots: 1, width: 1, depth: 1);
+            TestScope scope = scene.Add<TestScope>("Root 1");
+
+            // Bind
+            scope.BindComponent<ComponentDependency>()
+                .ToID("qualified", "alternate")
+                .FromSelf();
+
+            scope.BindComponent<ComponentDependency>()
+                .ToID("alternate", "other")
+                .FromAnywhere();
+
+            // Build graph and fetch binding nodes
+            ScopeNode scopeNode = CreateScopeNode(scene, "Root 1");
+            BindingNode firstBinding = scopeNode.BindingNodes[0];
+            BindingNode secondBinding = scopeNode.BindingNodes[1];
+
+            // Assert
+            Assert.That(firstBinding, Is.EqualTo(secondBinding));
+        }
+
+        [Test]
+        public void BindingNode_SameScope_TConcrete_WithOnlyDifferentIDQualifiers_IsNotEqual()
+        {
+            // Set up scene
+            TestScene scene = TestScene.Create(roots: 1, width: 1, depth: 1);
+            TestScope scope = scene.Add<TestScope>("Root 1");
+
+            // Bind
+            scope.BindComponent<ComponentDependency>()
+                .ToID("qualified", "alternate")
+                .FromSelf();
+
+            scope.BindComponent<ComponentDependency>()
+                .ToID("other", "fallback")
+                .FromAnywhere();
+
+            // Build graph and fetch binding nodes
+            ScopeNode scopeNode = CreateScopeNode(scene, "Root 1");
+            BindingNode firstBinding = scopeNode.BindingNodes[0];
+            BindingNode secondBinding = scopeNode.BindingNodes[1];
+
+            // Assert
+            Assert.That(firstBinding, Is.Not.EqualTo(secondBinding));
+        }
+
+        [Test]
+        public void BindingNode_SameScope_TConcrete_WithIDAndTargetQualifiers_IsNotEqual()
         {
             // Set up scene
             TestScene scene = TestScene.Create(roots: 1, width: 1, depth: 1);
@@ -199,6 +249,59 @@ namespace Tests.Saneject.Editor.Binding.Equality
 
             scope.BindComponent<ComponentDependency>()
                 .ToTarget<SingleConcreteComponentTarget>()
+                .FromAnywhere();
+
+            // Build graph and fetch binding nodes
+            ScopeNode scopeNode = CreateScopeNode(scene, "Root 1");
+            BindingNode firstBinding = scopeNode.BindingNodes[0];
+            BindingNode secondBinding = scopeNode.BindingNodes[1];
+
+            // Assert
+            Assert.That(firstBinding, Is.Not.EqualTo(secondBinding));
+        }
+
+        [Test]
+        public void BindingNode_SameScope_TConcrete_WithIDAndOverlappingTargetAndMemberQualifiers_IsNotEqual()
+        {
+            // Set up scene
+            TestScene scene = TestScene.Create(roots: 1, width: 1, depth: 1);
+            TestScope scope = scene.Add<TestScope>("Root 1");
+
+            // Bind
+            scope.BindComponent<ComponentDependency>()
+                .ToTarget<SingleConcreteComponentTarget>()
+                .ToMember("dependency")
+                .FromSelf();
+
+            scope.BindComponent<ComponentDependency>()
+                .ToID("qualified")
+                .ToTarget<SingleConcreteComponentTarget>()
+                .ToMember("dependency")
+                .FromAnywhere();
+
+            // Build graph and fetch binding nodes
+            ScopeNode scopeNode = CreateScopeNode(scene, "Root 1");
+            BindingNode firstBinding = scopeNode.BindingNodes[0];
+            BindingNode secondBinding = scopeNode.BindingNodes[1];
+
+            // Assert
+            Assert.That(firstBinding, Is.Not.EqualTo(secondBinding));
+        }
+
+        [Test]
+        public void BindingNode_SameScope_TConcrete_WithOverlappingTargetAndMemberQualifiers_IsEqual()
+        {
+            // Set up scene
+            TestScene scene = TestScene.Create(roots: 1, width: 1, depth: 1);
+            TestScope scope = scene.Add<TestScope>("Root 1");
+
+            // Bind
+            scope.BindComponent<ComponentDependency>()
+                .ToTarget<SingleConcreteComponentTarget>()
+                .FromSelf();
+
+            scope.BindComponent<ComponentDependency>()
+                .ToMember("dependency")
                 .FromAnywhere();
 
             // Build graph and fetch binding nodes

--- a/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Binding/Equality/BindingNodeEqualityTests.cs
+++ b/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Binding/Equality/BindingNodeEqualityTests.cs
@@ -161,7 +161,7 @@ namespace Tests.Saneject.Editor.Binding.Equality
         }
 
         [Test]
-        public void BindingNode_SameScope_TConcrete_WithOnlyIDQualifiers_IsNotEqual()
+        public void BindingNode_SameScope_TConcrete_WithOnlyIDQualifiers_IsEqual()
         {
             // Set up scene
             TestScene scene = TestScene.Create(roots: 1, width: 1, depth: 1);
@@ -182,7 +182,32 @@ namespace Tests.Saneject.Editor.Binding.Equality
             BindingNode secondBinding = scopeNode.BindingNodes[1];
 
             // Assert
-            Assert.That(firstBinding, Is.Not.EqualTo(secondBinding));
+            Assert.That(firstBinding, Is.EqualTo(secondBinding));
+        }
+
+        [Test]
+        public void BindingNode_SameScope_TConcrete_WithIDAndTargetQualifiers_IsEqual()
+        {
+            // Set up scene
+            TestScene scene = TestScene.Create(roots: 1, width: 1, depth: 1);
+            TestScope scope = scene.Add<TestScope>("Root 1");
+
+            // Bind
+            scope.BindComponent<ComponentDependency>()
+                .ToID("qualified")
+                .FromSelf();
+
+            scope.BindComponent<ComponentDependency>()
+                .ToTarget<SingleConcreteComponentTarget>()
+                .FromAnywhere();
+
+            // Build graph and fetch binding nodes
+            ScopeNode scopeNode = CreateScopeNode(scene, "Root 1");
+            BindingNode firstBinding = scopeNode.BindingNodes[0];
+            BindingNode secondBinding = scopeNode.BindingNodes[1];
+
+            // Assert
+            Assert.That(firstBinding, Is.EqualTo(secondBinding));
         }
 
         [Test]

--- a/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Binding/Qualification/ComponentBindingQualifierTests.cs
+++ b/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Binding/Qualification/ComponentBindingQualifierTests.cs
@@ -131,5 +131,60 @@ namespace Tests.Saneject.Editor.Binding.Qualification
             Assert.That(matchingTarget.dependency, Is.EqualTo(dependency));
             Assert.That(nonMatchingTarget.dependency, Is.Null);
         }
+
+        [Test]
+        public void ToTarget_Generic_TConcrete_InjectsNestedSerializableTarget()
+        {
+            // Set up scene
+            TestScene scene = TestScene.Create(roots: 1, width: 1, depth: 2);
+            TestScope scope = scene.Add<TestScope>("Root 1");
+            NestedRootTarget target = scene.Add<NestedRootTarget>("Root 1");
+
+            // Find dependency
+            AssetDependency assetDependency = Resources.Load<AssetDependency>("AssetDependency 1");
+            ComponentDependency singleDependency = scene.Add<ComponentDependency>("Root 1");
+
+            ComponentDependency[] dependencies =
+            {
+                singleDependency,
+                scene.Add<ComponentDependency>("Root 1/Child 1")
+            };
+
+            // Bind
+            scope.BindAsset<AssetDependency>()
+                .ToTarget<NestedChildTarget>()
+                .FromAssetLoad("Assets/Tests/Saneject/Fixtures/Resources/AssetDependency 1.asset");
+
+            scope.BindAsset<AssetDependency>()
+                .ToID("nested-method-id")
+                .ToTarget<NestedChildTarget>()
+                .FromAssetLoad("Assets/Tests/Saneject/Fixtures/Resources/AssetDependency 1.asset");
+
+            scope.BindComponents<ComponentDependency>()
+                .ToID("nested-method-id")
+                .ToTarget<NestedChildTarget>()
+                .FromDescendants(includeSelf: true);
+
+            scope.BindComponent<IDependency>()
+                .ToID("nested-method-id")
+                .ToTarget<NestedChildTarget>()
+                .FromSelf();
+
+            // Inject
+            InjectionRunner.Run(scene.Roots, ContextWalkFilter.SceneObjects);
+
+            // Assert
+            Assert.That(assetDependency, Is.Not.Null);
+            Assert.That(target.nested.nestedFieldDependency, Is.EqualTo(assetDependency));
+            Assert.That(target.nested.NestedMethodAssetDependency, Is.EqualTo(assetDependency));
+
+            CollectionAssert.AreEquivalent
+            (
+                dependencies,
+                target.nested.NestedMethodComponentDependencies
+            );
+
+            Assert.That(target.nested.NestedMethodInterfaceDependency, Is.EqualTo(singleDependency));
+        }
     }
 }

--- a/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Graph/InjectionGraphMemberTests.cs
+++ b/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Graph/InjectionGraphMemberTests.cs
@@ -47,7 +47,6 @@ namespace Tests.Saneject.Editor.Graph
 
             FieldNode concreteFieldNode = concreteFieldComponentNode.FieldNodes.Single();
             Assert.That(concreteFieldNode.Owner, Is.EqualTo(concreteFieldComponentNode.Component));
-            Assert.That(concreteFieldNode.DeclaringType, Is.EqualTo(typeof(SingleConcreteComponentTarget)));
             Assert.That(concreteFieldNode.QualifyingName, Is.EqualTo("dependency"));
             Assert.That(concreteFieldNode.InjectId, Is.Null);
             Assert.That(concreteFieldNode.SuppressMissingErrors, Is.False);
@@ -61,7 +60,6 @@ namespace Tests.Saneject.Editor.Graph
             Assert.That(concreteFieldNode.ShortPath, Is.EqualTo("SingleConcreteComponentTarget.dependency"));
 
             FieldNode interfaceFieldNode = interfaceFieldComponentNode.FieldNodes.Single();
-            Assert.That(interfaceFieldNode.DeclaringType, Is.EqualTo(typeof(SingleInterfaceTarget)));
             Assert.That(interfaceFieldNode.QualifyingName, Is.EqualTo("dependency"));
             Assert.That(interfaceFieldNode.FieldType, Is.EqualTo(typeof(IDependency)));
             Assert.That(interfaceFieldNode.RequestedType, Is.EqualTo(typeof(IDependency)));
@@ -73,7 +71,6 @@ namespace Tests.Saneject.Editor.Graph
             Assert.That(interfaceFieldNode.ShortPath, Is.EqualTo("SingleInterfaceTarget.dependency"));
 
             FieldNode concretePropertyNode = concretePropertyComponentNode.FieldNodes.Single();
-            Assert.That(concretePropertyNode.DeclaringType, Is.EqualTo(typeof(SingleConcreteComponentPropertyTarget)));
             Assert.That(concretePropertyNode.QualifyingName, Is.EqualTo("Dependency"));
             Assert.That(concretePropertyNode.FieldType, Is.EqualTo(typeof(ComponentDependency)));
             Assert.That(concretePropertyNode.RequestedType, Is.EqualTo(typeof(ComponentDependency)));
@@ -163,7 +160,6 @@ namespace Tests.Saneject.Editor.Graph
 
             MethodNode singleMethodNode = singleMethodComponentNode.MethodNodes.Single();
             Assert.That(singleMethodNode.Owner, Is.EqualTo(singleMethodComponentNode.Component));
-            Assert.That(singleMethodNode.DeclaringType, Is.EqualTo(typeof(SingleConcreteComponentMethodTarget)));
             Assert.That(singleMethodNode.QualifyingName, Is.EqualTo("Inject"));
             Assert.That(singleMethodNode.InjectId, Is.Null);
             Assert.That(singleMethodNode.SuppressMissingErrors, Is.False);
@@ -282,14 +278,12 @@ namespace Tests.Saneject.Editor.Graph
             Assert.That(componentNode.MethodNodes.Count, Is.EqualTo(2));
 
             Assert.That(topLevelFieldNode.Owner, Is.EqualTo(target));
-            Assert.That(topLevelFieldNode.DeclaringType, Is.EqualTo(typeof(NestedRootTarget)));
             Assert.That(topLevelFieldNode.InjectId, Is.EqualTo("field-id"));
             Assert.That(topLevelFieldNode.SuppressMissingErrors, Is.True);
             Assert.That(topLevelFieldNode.DisplayPath, Is.EqualTo("Root 1/NestedRootTarget/fieldDependency"));
             Assert.That(topLevelFieldNode.ShortPath, Is.EqualTo("NestedRootTarget.fieldDependency"));
 
             Assert.That(topLevelPropertyNode.Owner, Is.EqualTo(target));
-            Assert.That(topLevelPropertyNode.DeclaringType, Is.EqualTo(typeof(NestedRootTarget)));
             Assert.That(topLevelPropertyNode.InjectId, Is.EqualTo("property-id"));
             Assert.That(topLevelPropertyNode.SuppressMissingErrors, Is.True);
             Assert.That(topLevelPropertyNode.TypeShape, Is.EqualTo(TypeShape.List));
@@ -299,14 +293,12 @@ namespace Tests.Saneject.Editor.Graph
             Assert.That(topLevelPropertyNode.ShortPath, Is.EqualTo("NestedRootTarget.PropertyDependencies"));
 
             Assert.That(nestedFieldNode.Owner, Is.EqualTo(target.nested));
-            Assert.That(nestedFieldNode.DeclaringType, Is.EqualTo(typeof(NestedChildTarget)));
             Assert.That(nestedFieldNode.InjectId, Is.Null);
             Assert.That(nestedFieldNode.SuppressMissingErrors, Is.False);
             Assert.That(nestedFieldNode.DisplayPath, Is.EqualTo("Root 1/NestedRootTarget/nested.nestedFieldDependency"));
             Assert.That(nestedFieldNode.ShortPath, Is.EqualTo("NestedChildTarget.nestedFieldDependency"));
 
             Assert.That(nestedPropertyNode.Owner, Is.EqualTo(target.nested));
-            Assert.That(nestedPropertyNode.DeclaringType, Is.EqualTo(typeof(NestedChildTarget)));
             Assert.That(nestedPropertyNode.InjectId, Is.EqualTo("nested-property-id"));
             Assert.That(nestedPropertyNode.SuppressMissingErrors, Is.True);
             Assert.That(nestedPropertyNode.IsPropertyBackingField, Is.True);
@@ -314,7 +306,6 @@ namespace Tests.Saneject.Editor.Graph
             Assert.That(nestedPropertyNode.ShortPath, Is.EqualTo("NestedChildTarget.NestedPropertyDependency"));
 
             Assert.That(deepFieldNode.Owner, Is.EqualTo(target.nested.deepNested));
-            Assert.That(deepFieldNode.DeclaringType, Is.EqualTo(typeof(NestedDeepTarget)));
             Assert.That(deepFieldNode.InjectId, Is.EqualTo("deep-field-id"));
             Assert.That(deepFieldNode.SuppressMissingErrors, Is.True);
             Assert.That(deepFieldNode.DisplayPath, Is.EqualTo("Root 1/NestedRootTarget/nested.deepNested.deepFieldDependency"));
@@ -323,7 +314,6 @@ namespace Tests.Saneject.Editor.Graph
             CollectionAssert.IsEmpty(componentNode.FieldNodes.Where(node => node.DisplayPath.Contains("nullNested")).ToArray());
 
             Assert.That(topLevelMethodNode.Owner, Is.EqualTo(target));
-            Assert.That(topLevelMethodNode.DeclaringType, Is.EqualTo(typeof(NestedRootTarget)));
             Assert.That(topLevelMethodNode.InjectId, Is.EqualTo("method-id"));
             Assert.That(topLevelMethodNode.SuppressMissingErrors, Is.True);
             Assert.That(topLevelMethodNode.DisplayPath, Is.EqualTo("Root 1/NestedRootTarget/InjectTopLevel"));
@@ -342,7 +332,6 @@ namespace Tests.Saneject.Editor.Graph
             );
 
             Assert.That(nestedMethodNode.Owner, Is.EqualTo(target.nested));
-            Assert.That(nestedMethodNode.DeclaringType, Is.EqualTo(typeof(NestedChildTarget)));
             Assert.That(nestedMethodNode.InjectId, Is.EqualTo("nested-method-id"));
             Assert.That(nestedMethodNode.SuppressMissingErrors, Is.False);
             Assert.That(nestedMethodNode.DisplayPath, Is.EqualTo("Root 1/NestedRootTarget/nested.InjectNested"));


### PR DESCRIPTION
## Changes

- ID-qualified injection sites now require a matching `ToID(...)` binding. Unqualified bindings only match injection sites without an ID.
- If an `[Inject("id")]` site previously relied on an unqualified binding, add `.ToID("id")` to the binding or remove the ID from the injection site.

## Fixes

- Fixed `ToTarget<T>` matching for inherited and nested targets. `.ToTarget<Base>()` now matches derived target types, `.ToTarget<Derived>()` also applies to inherited injection members on the same derived target, and nested serializable injection targets are matched by their nested owner type.
- Fixed binding validation for duplicate or ambiguous qualifier combinations that could resolve the same injection site.