### PR TITLE
Filter resolution candidates by both interface and concrete type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ﻿# Changelog
 
+## Version 1.2.1
+
+### Fixes
+
+- Fixed component and asset resolution ignoring the concrete type when a binding specified both an interface and a concrete type. Candidates are now filtered by both interface and concrete type, so the binding resolves the requested concrete type instead of returning the first interface match.
+
+### Tests
+
+- Added a regression test ensuring an interface plus concrete component binding resolves the specified concrete type when multiple interface implementers exist.
+
 ## Version 1.2.0
 
 ### Added

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Core/Locator.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Core/Locator.cs
@@ -37,46 +37,12 @@ namespace Plugins.Saneject.Editor.Core
                 _ => throw new ArgumentOutOfRangeException()
             };
 
-            List<Object> validCandidates = new();
-
-            foreach (Object candidate in allCandidates)
-            {
-                if (CanSkipContextChecks(bindingNode, candidate))
-                {
-                    validCandidates.Add(candidate);
-                    continue;
-                }
-
-                ContextIdentity candidateContext = new(candidate);
-                ContextIdentity scopeContext = bindingNode.ScopeNode.TransformNode.ContextIdentity;
-
-                bool isContextMatch =
-                    ProjectSettings.UseContextIsolation
-                        ? candidateContext.Equals(scopeContext)
-                        : candidateContext.ContainerType == scopeContext.ContainerType &&
-                          candidateContext.ContainerId == scopeContext.ContainerId;
-
-                if (isContextMatch)
-                    validCandidates.Add(candidate);
-                else
-                    rejectedTypes.Add(candidate.GetType());
-            }
-
-            candidates = validCandidates.ToArray();
-        }
-
-        private static bool CanSkipContextChecks(
-            BindingNode bindingNode,
-            Object candidate)
-        {
-            // Persistent assets resolved through asset bindings bypass context checks because they are treated as contextless injected assets. Runtime proxies do too, even though they come from component bindings.
-            if (!EditorUtility.IsPersistent(candidate))
-                return false;
-
-            if (bindingNode is AssetBindingNode)
-                return true;
-
-            return bindingNode is ComponentBindingNode && candidate is RuntimeProxyBase;
+            candidates = GetContextFilteredCandidates
+            (
+                bindingNode,
+                allCandidates,
+                rejectedTypes
+            );
         }
 
         private static IEnumerable<Object> LocateComponentCandidates(
@@ -185,17 +151,7 @@ namespace Plugins.Saneject.Editor.Core
                 _ => throw new ArgumentOutOfRangeException()
             };
 
-            if (candidates != null && bindingNode.DependencyFilters.Count > 0)
-                try
-                {
-                    candidates = candidates.Where(component => bindingNode.DependencyFilters.All(f => f.Filter(component))).ToArray();
-                }
-                catch (Exception e)
-                {
-                    candidates = null;
-                    context.RegisterError(new FilterCandidatesError(bindingNode, e));
-                }
-
+            candidates = GetTypeAndDependencyFilteredCandidates(context, bindingNode, candidates);
             return candidates ?? Enumerable.Empty<Component>();
         }
 
@@ -232,13 +188,27 @@ namespace Plugins.Saneject.Editor.Core
                 _ => throw new ArgumentOutOfRangeException()
             };
 
+            candidates = GetTypeAndDependencyFilteredCandidates(context, bindingNode, candidates);
+            return candidates ?? Enumerable.Empty<Object>();
+        }
+
+        private static IEnumerable<T> GetTypeAndDependencyFilteredCandidates<T>(
+            InjectionContext context,
+            BindingNode bindingNode,
+            IEnumerable<T> candidates) where T : Object
+        {
             if (bindingNode.InterfaceType != null)
-                candidates = candidates.Where(asset => bindingNode.InterfaceType.IsAssignableFrom(asset.GetType()));
+                candidates = candidates?.Where(asset => bindingNode.InterfaceType.IsAssignableFrom(asset.GetType()));
+
+            if (bindingNode.ConcreteType != null)
+                candidates = candidates?.Where(asset => asset.GetType() == bindingNode.ConcreteType);
 
             if (candidates != null && bindingNode.DependencyFilters.Count > 0)
                 try
                 {
-                    candidates = candidates.Where(asset => bindingNode.DependencyFilters.All(f => f.Filter(asset))).ToArray();
+                    candidates = candidates
+                        .Where(x => bindingNode.DependencyFilters.All(f => f.Filter(x)))
+                        .ToArray();
                 }
                 catch (Exception e)
                 {
@@ -246,7 +216,54 @@ namespace Plugins.Saneject.Editor.Core
                     context.RegisterError(new FilterCandidatesError(bindingNode, e));
                 }
 
-            return candidates ?? Enumerable.Empty<Object>();
+            return candidates;
+        }
+
+        private static Object[] GetContextFilteredCandidates(
+            BindingNode bindingNode,
+            IEnumerable<Object> allCandidates,
+            HashSet<Type> rejectedTypes)
+        {
+            List<Object> validCandidates = new();
+
+            foreach (Object candidate in allCandidates)
+            {
+                if (CanSkipContextChecks(bindingNode, candidate))
+                {
+                    validCandidates.Add(candidate);
+                    continue;
+                }
+
+                ContextIdentity candidateContext = new(candidate);
+                ContextIdentity scopeContext = bindingNode.ScopeNode.TransformNode.ContextIdentity;
+
+                bool isContextMatch =
+                    ProjectSettings.UseContextIsolation
+                        ? candidateContext.Equals(scopeContext)
+                        : candidateContext.ContainerType == scopeContext.ContainerType &&
+                          candidateContext.ContainerId == scopeContext.ContainerId;
+
+                if (isContextMatch)
+                    validCandidates.Add(candidate);
+                else
+                    rejectedTypes.Add(candidate.GetType());
+            }
+
+            return validCandidates.ToArray();
+
+            static bool CanSkipContextChecks(
+                BindingNode bindingNode,
+                Object candidate)
+            {
+                // Persistent assets resolved through asset bindings bypass context checks because they are treated as contextless injected assets. Runtime proxies do too, even though they come from component bindings.
+                if (!EditorUtility.IsPersistent(candidate))
+                    return false;
+
+                if (bindingNode is AssetBindingNode)
+                    return true;
+
+                return bindingNode is ComponentBindingNode && candidate is RuntimeProxyBase;
+            }
         }
 
         private static IEnumerable<T> ToEnumerable<T>(this T item)

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
@@ -2,7 +2,7 @@
   "name": "com.alexanderlarsen.saneject",
   "author": "Alexander Larsen",
   "displayName": "Saneject",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Inject dependencies in the Unity Editor, not Play Mode, by writing them directly into serialized fields at edit-time using familiar DI APIs, so everything stays visible in the Inspector, including interfaces.\n\nNo runtime container. No startup cost. No hidden wiring. No weird lifecycles. Just simple, deterministic edit-time DI that works with Unity, not around it.",
   "documentationUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/README.md",
   "changelogUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/CHANGELOG.md",

--- a/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Injection/InterfaceConcreteResolutionTests.cs
+++ b/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Injection/InterfaceConcreteResolutionTests.cs
@@ -1,0 +1,35 @@
+using NUnit.Framework;
+using Plugins.Saneject.Editor.Core;
+using Plugins.Saneject.Editor.Data.Context;
+using Tests.Saneject.Fixtures.Scripts;
+using Tests.Saneject.Fixtures.Scripts.Dependencies;
+using Tests.Saneject.Fixtures.Scripts.InjectionTargets;
+
+namespace Tests.Saneject.Editor.Injection
+{
+    public class InterfaceConcreteResolutionTests
+    {
+        [Test]
+        public void Inject_TInterfaceTConcrete_WHEN_MultipleInterfaceImplementers_InjectsConcreteComponentToInterfaceField()
+        {
+            // Set up scene
+            TestScene scene = TestScene.Create(roots: 1, width: 2, depth: 2);
+            TestScope scope = scene.Add<TestScope>("Root 1");
+            SingleInterfaceTarget target = scene.Add<SingleInterfaceTarget>("Root 1");
+
+            // Find dependency
+            scene.Add<ComponentDependency>("Root 1/Child 1");
+            IDependency dependency = scene.Add<SecondComponentDependency>("Root 1/Child 2");
+
+            // Bind
+            scope.BindComponent<IDependency, SecondComponentDependency>().FromDescendants(includeSelf: false);
+
+            // Inject
+            InjectionRunner.Run(scene.Roots, ContextWalkFilter.SceneObjects);
+
+            // Assert
+            Assert.That(dependency, Is.Not.Null);
+            Assert.That(target.dependency, Is.EqualTo(dependency));
+        }
+    }
+}

--- a/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Injection/InterfaceConcreteResolutionTests.cs.meta
+++ b/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Injection/InterfaceConcreteResolutionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 080cc4c551464bbc828206e52dfbf9c9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityProject/Saneject/Assets/Tests/Saneject/Fixtures/Scripts/Dependencies/SecondComponentDependency.cs
+++ b/UnityProject/Saneject/Assets/Tests/Saneject/Fixtures/Scripts/Dependencies/SecondComponentDependency.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+namespace Tests.Saneject.Fixtures.Scripts.Dependencies
+{
+    public class SecondComponentDependency : MonoBehaviour, IDependency
+    {
+    }
+}

--- a/UnityProject/Saneject/Assets/Tests/Saneject/Fixtures/Scripts/Dependencies/SecondComponentDependency.cs.meta
+++ b/UnityProject/Saneject/Assets/Tests/Saneject/Fixtures/Scripts/Dependencies/SecondComponentDependency.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e122e95bb56145a2aa68338eb3acbb90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
- Filter candidates by concrete type in addition to interface type in `Locator`, so a binding specifying both an interface and a concrete type resolves the concrete type instead of the first interface match
- Extract type and dependency filtering into a shared `GetTypeAndDependencyFilteredCandidates` method used by both component and asset resolution
- Rename `ApplyTypeAndDependencyFilters` and `ApplyContextFilters` to `GetTypeAndDependencyFilteredCandidates` and `GetContextFilteredCandidates`
- Add `SecondComponentDependency` fixture (a second `IDependency` implementer) to support multi-implementer resolution tests
- Add `InterfaceConcreteResolutionTests` regression test covering interface plus concrete component bindings when multiple interface implementers exist
- Bump package version to 1.2.1 and add changelog notes