### PR TITLE
Fix abstract/base-class binding resolution regression from 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ﻿# Changelog
 
+## Version 1.2.3
+
+### Fixes
+
+- Fixed a regression from 1.2.1 where component and asset bindings on an abstract or base type (e.g. `BindComponent<Collider>()`) no longer resolved derived instances. Concrete-type candidate filtering now uses `IsAssignableFrom` instead of exact type equality, so a binding resolves the bound type or any subclass, matching Unity's `GetComponent<T>()` semantics. Interface plus concrete bindings still require candidates to satisfy both types.
+
+### Tests
+
+- Added regression coverage for base and abstract class component resolution, and for interface plus concrete bindings resolving a subclass of the concrete type.
+
 ## Version 1.2.2
 
 ### Unity 6000.4 and 6000.5 support

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Core/Locator.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Core/Locator.cs
@@ -198,10 +198,10 @@ namespace Plugins.Saneject.Editor.Core
             IEnumerable<T> candidates) where T : Object
         {
             if (bindingNode.InterfaceType != null)
-                candidates = candidates?.Where(asset => bindingNode.InterfaceType.IsAssignableFrom(asset.GetType()));
+                candidates = candidates?.Where(x => bindingNode.InterfaceType.IsAssignableFrom(x.GetType()));
 
             if (bindingNode.ConcreteType != null)
-                candidates = candidates?.Where(asset => asset.GetType() == bindingNode.ConcreteType);
+                candidates = candidates?.Where(x => bindingNode.ConcreteType.IsAssignableFrom(x.GetType()));
 
             if (candidates != null && bindingNode.DependencyFilters.Count > 0)
                 try

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
@@ -2,7 +2,7 @@
   "name": "com.alexanderlarsen.saneject",
   "author": "Alexander Larsen",
   "displayName": "Saneject",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Inject dependencies in the Unity Editor, not Play Mode, by writing them directly into serialized fields at edit-time using familiar DI APIs, so everything stays visible in the Inspector, including interfaces.\n\nNo runtime container. No startup cost. No hidden wiring. No weird lifecycles. Just simple, deterministic edit-time DI that works with Unity, not around it.",
   "documentationUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/README.md",
   "changelogUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/CHANGELOG.md",

--- a/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Injection/InterfaceConcreteResolutionTests.cs
+++ b/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Injection/InterfaceConcreteResolutionTests.cs
@@ -31,5 +31,49 @@ namespace Tests.Saneject.Editor.Injection
             Assert.That(dependency, Is.Not.Null);
             Assert.That(target.dependency, Is.EqualTo(dependency));
         }
+
+        [Test]
+        public void Inject_TConcrete_WHEN_CandidateIsSubclass_ResolvesSubclassToConcreteField()
+        {
+            // Set up scene
+            TestScene scene = TestScene.Create(roots: 1, width: 3, depth: 3);
+            TestScope scope = scene.Add<TestScope>("Root 1");
+            SingleConcreteComponentTarget target = scene.Add<SingleConcreteComponentTarget>("Root 1/Child 1");
+
+            // Find dependency (a subclass of the bound concrete type)
+            DerivedComponentDependency dependency = scene.Add<DerivedComponentDependency>("Root 1/Child 1/Child 1");
+
+            // Bind the base type; resolution should behave like GetComponent<ComponentDependency>() and match the subclass
+            scope.BindComponent<ComponentDependency>().FromDescendants(includeSelf: false);
+
+            // Inject
+            InjectionRunner.Run(scene.Roots, ContextWalkFilter.SceneObjects);
+
+            // Assert
+            Assert.That(dependency, Is.Not.Null);
+            Assert.That(target.dependency, Is.EqualTo(dependency));
+        }
+
+        [Test]
+        public void Inject_TInterfaceTConcrete_WHEN_CandidateIsSubclassOfConcrete_ResolvesSubclassFulfillingBoth()
+        {
+            // Set up scene
+            TestScene scene = TestScene.Create(roots: 1, width: 3, depth: 3);
+            TestScope scope = scene.Add<TestScope>("Root 1");
+            SingleInterfaceTarget target = scene.Add<SingleInterfaceTarget>("Root 1/Child 1");
+
+            // Find dependency (subclass of the bound concrete, also implements the interface)
+            DerivedComponentDependency dependency = scene.Add<DerivedComponentDependency>("Root 1/Child 1/Child 1");
+
+            // Bind interface + concrete; the candidate must be assignable to both
+            scope.BindComponent<IDependency, ComponentDependency>().FromDescendants(includeSelf: false);
+
+            // Inject
+            InjectionRunner.Run(scene.Roots, ContextWalkFilter.SceneObjects);
+
+            // Assert
+            Assert.That(dependency, Is.Not.Null);
+            Assert.That(target.dependency, Is.EqualTo(dependency));
+        }
     }
 }

--- a/UnityProject/Saneject/Assets/Tests/Saneject/Fixtures/Scripts/Dependencies/DerivedComponentDependency.cs
+++ b/UnityProject/Saneject/Assets/Tests/Saneject/Fixtures/Scripts/Dependencies/DerivedComponentDependency.cs
@@ -1,0 +1,6 @@
+namespace Tests.Saneject.Fixtures.Scripts.Dependencies
+{
+    public class DerivedComponentDependency : ComponentDependency
+    {
+    }
+}

--- a/UnityProject/Saneject/Assets/Tests/Saneject/Fixtures/Scripts/Dependencies/DerivedComponentDependency.cs.meta
+++ b/UnityProject/Saneject/Assets/Tests/Saneject/Fixtures/Scripts/Dependencies/DerivedComponentDependency.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f93230bd584c4b4bb2eb6c51a0381946
+timeCreated: 1774259741


### PR DESCRIPTION
- Locator: filter concrete-type candidates with IsAssignableFrom instead of exact type equality, so BindComponent<T>() resolves T or any subclass (like GetComponent<T>()); interface+concrete still requires both types
- Add DerivedComponentDependency fixture and regression tests for base-class resolution and interface+concrete subclass resolution
- Changelog and version bump to 1.2.3