### PR TITLE
Fix StackOverflowException from Dictionary properties during injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ﻿# Changelog
 
+## Version 1.2.4
+
+### Fixes
+
+- Fixed a `StackOverflowException` during injection when a component exposed a `Dictionary` property that had been iterated at edit time (e.g. from `OnDrawGizmos`), which leaves an internal reference cycle for traversal to follow. Generic collection types are no longer treated as nested serializable, so injection no longer recurses into their internal fields.
+
+### Tests
+
+- Added coverage ensuring generic collection types are excluded from nested serializable traversal while plain `[Serializable]` classes are still included.
+
 ## Version 1.2.3
 
 ### Fixes

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Extensions/TypeExtensions.cs
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/Editor/Extensions/TypeExtensions.cs
@@ -45,6 +45,12 @@ namespace Plugins.Saneject.Editor.Extensions
             if (type == typeof(string))
                 return false;
 
+            // Unity does not serialize generic types (e.g. Dictionary<,>, List<T>) as nested custom
+            // classes, and their internal fields can form reference cycles (Dictionary <-> ValueCollection),
+            // so never recurse into them during traversal.
+            if (type.IsGenericType)
+                return false;
+
             return !typeof(Object).IsAssignableFrom(type) &&
                    type.IsDefined(typeof(SerializableAttribute), inherit: false);
         }

--- a/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
+++ b/UnityProject/Saneject/Assets/Plugins/Saneject/package.json
@@ -2,7 +2,7 @@
   "name": "com.alexanderlarsen.saneject",
   "author": "Alexander Larsen",
   "displayName": "Saneject",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Inject dependencies in the Unity Editor, not Play Mode, by writing them directly into serialized fields at edit-time using familiar DI APIs, so everything stays visible in the Inspector, including interfaces.\n\nNo runtime container. No startup cost. No hidden wiring. No weird lifecycles. Just simple, deterministic edit-time DI that works with Unity, not around it.",
   "documentationUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/README.md",
   "changelogUrl": "https://github.com/alexanderlarsen/Saneject/blob/main/CHANGELOG.md",

--- a/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Extensions.meta
+++ b/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Extensions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 59613578289354f46b93cc3377a0839f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Extensions/TypeExtensionsTests.cs
+++ b/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Extensions/TypeExtensionsTests.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Plugins.Saneject.Editor.Extensions;
+using Tests.Saneject.Fixtures.Scripts.InjectionTargets;
+using UnityEngine;
+
+namespace Tests.Saneject.Editor.Extensions
+{
+    public class TypeExtensionsTests
+    {
+        // Regression: generic collection types (e.g. Dictionary<,>, List<>) carry [Serializable] and would
+        // otherwise be treated as nested serializable, causing traversal to recurse into their internal
+        // fields. A Dictionary property's cached ValueCollection holds a back-reference to the dictionary,
+        // producing a reference cycle and an uncatchable StackOverflowException during injection.
+        [Test]
+        public void IsNestedSerializable_ReturnsFalse_ForGenericCollectionTypes()
+        {
+            Assert.That(typeof(Dictionary<Vector3, NestedChildTarget>).IsNestedSerializable(), Is.False);
+            Assert.That(typeof(List<NestedChildTarget>).IsNestedSerializable(), Is.False);
+        }
+
+        // Guard rail: the generic exclusion above must not stop plain [Serializable] user classes from
+        // being traversed for nested injection.
+        [Test]
+        public void IsNestedSerializable_ReturnsTrue_ForPlainSerializableClass()
+        {
+            Assert.That(typeof(NestedChildTarget).IsNestedSerializable(), Is.True);
+        }
+    }
+}

--- a/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Extensions/TypeExtensionsTests.cs.meta
+++ b/UnityProject/Saneject/Assets/Tests/Saneject/Editor/Extensions/TypeExtensionsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 934c45d16f9378f408e4436f6163e8a5


### PR DESCRIPTION
- Exclude generic collection types from nested serializable traversal
- Add regression tests for TypeExtensions.IsNestedSerializable
- Bump version to 1.2.4 and update CHANGELOG